### PR TITLE
Remove self-referential using to fix Julia 1.10 CI

### DIFF
--- a/src/demo_averaging/fix_annotation_ap_axis.jl
+++ b/src/demo_averaging/fix_annotation_ap_axis.jl
@@ -6,7 +6,6 @@ using ShroffCelegansModels.JSON3
 using ShroffCelegansModels.Dates
 using ShroffCelegansModels.Sockets
 using ShroffCelegansModels.HDF5
-using ShroffCelegansModels: swapyz_scale
 
 
 const ANNOTATION_PERSIST_SERVER_PORT = 3129


### PR DESCRIPTION
## Summary
- Deletes a no-op self-import (`using ShroffCelegansModels: swapyz_scale`) at `src/demo_averaging/fix_annotation_ap_axis.jl:9` that errors under Julia 1.10's eager binding resolution.

## Why
`swapyz_scale` is defined in the same module (`src/makie.jl`), so no `using` is needed. Under Julia 1.10, `using SelfModule: name` resolves eagerly at parse time, but the package's include order puts `fix_annotation_ap_axis.jl` (line 74 of `src/ShroffCelegansModels.jl`) before `makie.jl` (line 82), so the binding doesn't exist yet → `UndefVarError: swapyz_scale not defined`. Julia 1.11+ defers the resolution, hiding the issue on the test cluster.

## Test plan
- [ ] CI passes on Julia 1.10
- [ ] CI passes on Julia 1.11, 1.12, nightly
- [ ] Documentation job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)