### PR TITLE
Step 6 flat parallel priming, interactive static export & prod parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ backup/Project.toml
 # Local performance-assessment scratch + cloned dependency for dev (not committed)
 /bench/
 /ThinPlateSplines.jl/
+/scripts/_local_static_export_test.jl
+/movies/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ that are too detailed for CLAUDE.md. It is excluded from Docker builds
 (`.dockerignore`) but committed to git so notes are available on any checkout.
 
 Current notes:
+- `notes/trigger-recompute-pipeline.md` — how to manually trigger the recompute pipeline (plant marker + create Job from CronJob)
 - `notes/copy-movies-to-pvc.md` — how to manually copy MP4 movies to the OpenShift PVC
 - `notes/lsf-from-mac.md` — submitting and monitoring LSF jobs from a Mac via SSH
 - `notes/2026-06-09-recompute-seam-cells.md` — recompute run log (seam-cell injection)

--- a/deployment/shroff-data-test/01-configmap.yaml
+++ b/deployment/shroff-data-test/01-configmap.yaml
@@ -37,6 +37,11 @@ data:
             }
         }
 
+        # Redirect the bare paths to their trailing-slash form so the autoindex
+        # listing (and relative links within it) resolve correctly.
+        location = /recompute { return 301 /recompute/; }
+        location = /csv_archives { return 301 /csv_archives/; }
+
         location /recompute/ {
             alias /var/www/recompute/;
             autoindex on;

--- a/deployment/shroff-data-test/01-configmap.yaml
+++ b/deployment/shroff-data-test/01-configmap.yaml
@@ -19,6 +19,13 @@ data:
         root /app/ShroffCelegansModels.jl/web/static;
         index index.html;
 
+        # TLS terminates at the OpenShift router; nginx only sees http on :8080.
+        # Without this, nginx-generated redirects (the bare→trailing-slash 301s
+        # below, autoindex dir redirects, proxied 301s) emit an absolute Location
+        # of http://host:8080/… — non-routable externally. Relative redirects let
+        # the browser resolve them against the original https://host request.
+        absolute_redirect off;
+
         location / {
         }
 

--- a/deployment/shroff-data/01-configmap.yaml
+++ b/deployment/shroff-data/01-configmap.yaml
@@ -37,6 +37,40 @@ data:
             }
         }
 
+        location /recompute/ {
+            alias /var/www/recompute/;
+            autoindex on;
+            autoindex_exact_size off;
+            autoindex_localtime on;
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Max-Age' 1728000;
+                add_header 'Content-Type' 'text/plain; charset=utf-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
+        }
+
+        location /csv_archives/ {
+            alias /var/www/csv_archives/;
+            autoindex on;
+            autoindex_exact_size off;
+            autoindex_localtime on;
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Max-Age' 1728000;
+                add_header 'Content-Type' 'text/plain; charset=utf-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
+        }
+
         location /show_average_annotations/ {
             proxy_pass http://localhost:8180/;
             proxy_http_version 1.1;

--- a/deployment/shroff-data/01-configmap.yaml
+++ b/deployment/shroff-data/01-configmap.yaml
@@ -37,6 +37,11 @@ data:
             }
         }
 
+        # Redirect the bare paths to their trailing-slash form so the autoindex
+        # listing (and relative links within it) resolve correctly.
+        location = /recompute { return 301 /recompute/; }
+        location = /csv_archives { return 301 /csv_archives/; }
+
         location /recompute/ {
             alias /var/www/recompute/;
             autoindex on;

--- a/deployment/shroff-data/01-configmap.yaml
+++ b/deployment/shroff-data/01-configmap.yaml
@@ -19,6 +19,13 @@ data:
         root /app/ShroffCelegansModels.jl/web/static;
         index index.html;
 
+        # TLS terminates at the OpenShift router; nginx only sees http on :8080.
+        # Without this, nginx-generated redirects (the bare→trailing-slash 301s
+        # below, autoindex dir redirects, proxied 301s) emit an absolute Location
+        # of http://host:8080/… — non-routable externally. Relative redirects let
+        # the browser resolve them against the original https://host request.
+        absolute_redirect off;
+
         location / {
         }
 

--- a/deployment/shroff-data/02-pvc.yaml
+++ b/deployment/shroff-data/02-pvc.yaml
@@ -31,7 +31,11 @@ spec:
     readOnly: true
 ---
 ---
-# CephFS PVC for annotation_changes.h5 (user edits that must survive pod restarts).
+# CephFS PVC for annotation_changes.h5 (user edits) AND the recompute pipeline
+# output dir (/data/annotations/recompute: averaged HDF5s, caches, movies, the
+# interactive meshscatter_latest.html, archives). 20Gi matches the test env;
+# the recompute outputs + archives are ~300MB+ and grow per run. cephfs
+# allowVolumeExpansion=true, so this is an online resize.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -43,7 +47,7 @@ spec:
   storageClassName: ocs-storagecluster-cephfs
   resources:
     requests:
-      storage: 1Gi
+      storage: 20Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/deployment/shroff-data/03-deployment.yaml
+++ b/deployment/shroff-data/03-deployment.yaml
@@ -38,6 +38,14 @@ spec:
               readOnly: true
             - name: nginx-config
               mountPath: /etc/nginx/conf.d
+            - name: annotations
+              mountPath: /var/www/recompute
+              subPath: recompute
+              readOnly: true
+            - name: annotations
+              mountPath: /var/www/csv_archives
+              subPath: csv_archives
+              readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -60,6 +68,7 @@ spec:
           image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
           command:
             - julia
+            - --threads=auto
             - --project=/app/ShroffCelegansModels.jl/web
             - /app/ShroffCelegansModels.jl/web/scripts/web_show_average_annotations.jl
           ports:
@@ -72,12 +81,20 @@ spec:
             - name: nearline
               mountPath: /nearline/shroff
               readOnly: true
+            # read-only: load_latest_annotation_cache reads the recompute
+            # my_annotation_position_cache.h5 from /data/annotations/recompute
+            - name: annotations
+              mountPath: /data/annotations
+              readOnly: true
           resources:
             requests:
               memory: 4Gi
               cpu: 250m
             limits:
-              memory: 4Gi
+              # loads avg_models_n*.h5 + my_annotation_position_cache.h5 +
+              # annotations_cache.h5 from the PVC (larger than the old bundled
+              # snapshots); 4Gi OOM-killed it, so allow headroom.
+              memory: 8Gi
               cpu: "2"
           startupProbe:
             tcpSocket:
@@ -89,6 +106,7 @@ spec:
           image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
           command:
             - julia
+            - --threads=auto
             - --project=/app/ShroffCelegansModels.jl/web
             - /app/ShroffCelegansModels.jl/web/scripts/web_meshscatter_average_edited.jl
           ports:
@@ -101,12 +119,19 @@ spec:
             - name: nearline
               mountPath: /nearline/shroff
               readOnly: true
+            # read-only: load_latest_average_annotations reads the newest
+            # edited_smoothed_average_annotations_*.h5 from /data/annotations/recompute
+            - name: annotations
+              mountPath: /data/annotations
+              readOnly: true
           resources:
             requests:
               memory: 2Gi
               cpu: 250m
             limits:
-              memory: 3Gi
+              # recording a movie (Record button) renders all timepoints and
+              # re-encodes via VideoIO; 3Gi was OOM-killed (exit 137).
+              memory: 8Gi
               cpu: "2"
           startupProbe:
             tcpSocket:
@@ -118,6 +143,7 @@ spec:
           image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
           command:
             - julia
+            - --threads=auto
             - --project=/app/ShroffCelegansModels.jl/web
             - /app/ShroffCelegansModels.jl/web/scripts/web_meshscatter_average_edited_2024_10_24.jl
           ports:
@@ -130,12 +156,19 @@ spec:
             - name: nearline
               mountPath: /nearline/shroff
               readOnly: true
+            # read-only: load_latest_average_annotations reads the newest
+            # edited_smoothed_average_annotations_*.h5 from /data/annotations/recompute
+            - name: annotations
+              mountPath: /data/annotations
+              readOnly: true
           resources:
             requests:
               memory: 2Gi
               cpu: 250m
             limits:
-              memory: 3Gi
+              # recording a movie (Record button) renders all timepoints and
+              # re-encodes via VideoIO; 3Gi was OOM-killed (exit 137).
+              memory: 8Gi
               cpu: "2"
           startupProbe:
             tcpSocket:
@@ -147,6 +180,7 @@ spec:
           image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
           command:
             - julia
+            - --threads=auto
             - --project=/app/ShroffCelegansModels.jl/web
             - /app/ShroffCelegansModels.jl/web/scripts/web_debug_annotation_ap_axis.jl
           ports:
@@ -158,6 +192,10 @@ spec:
           volumeMounts:
             - name: nearline
               mountPath: /nearline/shroff
+              readOnly: true
+            # read-only: loading.jl reads avg_models_n*.h5 from /data/annotations/recompute
+            - name: annotations
+              mountPath: /data/annotations
               readOnly: true
           resources:
             requests:
@@ -176,6 +214,7 @@ spec:
           image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
           command:
             - julia
+            - --threads=auto
             - --project=/app/ShroffCelegansModels.jl/web
             - /app/ShroffCelegansModels.jl/web/scripts/web_debug_annotation_ap_axis_live.jl
           ports:
@@ -187,6 +226,10 @@ spec:
           volumeMounts:
             - name: nearline
               mountPath: /nearline/shroff
+              readOnly: true
+            # read-only: loading.jl reads avg_models_n*.h5 from /data/annotations/recompute
+            - name: annotations
+              mountPath: /data/annotations
               readOnly: true
           resources:
             requests:
@@ -205,6 +248,7 @@ spec:
           image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
           command:
             - julia
+            - --threads=auto
             - --project=/app/ShroffCelegansModels.jl/web
             - /app/ShroffCelegansModels.jl/web/scripts/web_debug_annotation_ap_axis_retrack_live.jl
           ports:
@@ -216,6 +260,10 @@ spec:
           volumeMounts:
             - name: nearline
               mountPath: /nearline/shroff
+              readOnly: true
+            # read-only: loading.jl reads avg_models_n*.h5 from /data/annotations/recompute
+            - name: annotations
+              mountPath: /data/annotations
               readOnly: true
           resources:
             requests:
@@ -230,10 +278,34 @@ spec:
             failureThreshold: 10
             periodSeconds: 30
 
+        - name: debug-zscore
+          image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
+          command: ["sleep", "infinity"]
+          workingDir: /app/ShroffCelegansModels.jl
+          env:
+            - name: SHROFF_HOST
+              value: "shroff-data.int.janelia.org"
+            - name: ANNOTATION_CHANGES_PATH
+              value: /data/annotations/annotation_changes.h5
+          volumeMounts:
+            - name: nearline
+              mountPath: /nearline/shroff
+              readOnly: true
+            - name: annotations
+              mountPath: /data/annotations
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 250m
+            limits:
+              memory: 8Gi
+              cpu: "2"
+
         - name: zscore-analysis
           image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
           command:
             - julia
+            - --threads=auto
             - --project=/app/ShroffCelegansModels.jl/web
             - /app/ShroffCelegansModels.jl/web/scripts/web_zscore_analysis.jl
           ports:
@@ -267,6 +339,7 @@ spec:
           image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
           command:
             - julia
+            - --threads=auto
             - --project=/app/ShroffCelegansModels.jl/web
             - /app/ShroffCelegansModels.jl/web/scripts/web_modified_times.jl
           ports:
@@ -298,6 +371,7 @@ spec:
           image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
           command:
             - julia
+            - --threads=auto
             - --project=/app/ShroffCelegansModels.jl/web
             - /app/ShroffCelegansModels.jl/web/scripts/web_fix_annotation_ap_axis.jl
           ports:

--- a/deployment/shroff-data/09-cronjob-recompute.yaml
+++ b/deployment/shroff-data/09-cronjob-recompute.yaml
@@ -1,0 +1,92 @@
+# Runs once daily at 03:00 ET, just after the 02:00 save-modified-times
+# CronJob; checks the shared annotations PVC for a `pending_recompute`
+# marker. When the marker is present, executes the recompute pipeline and
+# removes the marker on success.
+#
+# Schedule lowered from every-15-minutes to once-daily so the cron can't
+# race the long-running manual recompute jobs on the shared
+# /data/annotations/recompute/checkpoint/ directory (see task #41 — both
+# pipelines used the same path; cron's success-path rm wiped the manual
+# job's in-flight checkpoints, producing dozens of H5 ENOENT warnings).
+#
+# Uses the default ServiceAccount — no special RBAC needed because all
+# coordination happens via files on the shared PVC.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: recompute-on-mtime-change
+  namespace: shroff-data
+  labels:
+    app: shroff-data
+    component: recompute-on-mtime-change
+spec:
+  schedule: "0 3 * * *"
+  timeZone: "America/New_York"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      # 12h — a cold-cache full N=371 recompute can exceed the previous 4h
+      # (it did once, finishing only via an 8h resume job).
+      activeDeadlineSeconds: 43200
+      template:
+        metadata:
+          labels:
+            app: shroff-data
+            component: recompute-on-mtime-change
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: recompute-on-mtime-change
+              image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
+              command:
+                - julia
+                # Explicit thread count — NOT --threads=auto. In this cgroup, auto
+                # mis-detects the CPU budget (observed: 1 thread on the old 4-core
+                # pod, 100 threads on a 16-core test pod — it reads the 128-core
+                # node, not the cgroup quota). Pin it to match the cpu limit below
+                # so the step-6 dataset loop (Threads.@threads over 72 datasets)
+                # actually parallelizes. BLAS is pinned to 1 inside that loop in
+                # code (get_group_annotation_positions_over_time.jl) to avoid
+                # nthreads × blas_threads oversubscription.
+                - --threads=16
+                - --project=/app/ShroffCelegansModels.jl/web
+                - /app/ShroffCelegansModels.jl/web/scripts/run_recompute_if_needed.jl
+              workingDir: /app/ShroffCelegansModels.jl
+              env:
+                - name: MODIFIED_TIMES_DIR
+                  value: /data/annotations/modified_times
+                # Production-grade output requires N=371. Override here
+                # (env level) if you ever need a faster validation run with
+                # a different N.
+                - name: N_TIMEPOINTS
+                  value: "371"
+              volumeMounts:
+                - name: nearline
+                  mountPath: /nearline/shroff
+                  readOnly: true
+                - name: annotations
+                  mountPath: /data/annotations
+              # Burstable: guaranteed 4 cores, bursts to 16 when the node has them
+              # free (the step-6 averaging fans out over 72 independent datasets and
+              # scales ~linearly — a 16-thread CPU-bound test hit ~13.85× on this
+              # cluster). Memory raised for the 16 concurrent per-dataset working
+              # sets + per-thread TPS workspaces; the full positions cache (not the
+              # threading) dominates and fit in 8Gi single-threaded, so 32Gi is ample.
+              resources:
+                requests:
+                  memory: 8Gi
+                  cpu: "4"
+                limits:
+                  memory: 32Gi
+                  cpu: "16"
+          volumes:
+            - name: nearline
+              persistentVolumeClaim:
+                claimName: shroff-data-nearline
+            - name: annotations
+              persistentVolumeClaim:
+                claimName: shroff-data-annotations

--- a/deployment/shroff-data/10-job-csv-archives.yaml
+++ b/deployment/shroff-data/10-job-csv-archives.yaml
@@ -1,0 +1,63 @@
+# One-shot Job that gathers all per-dataset .csv files under /nearline
+# into per-dataset .tar.gz archives on the annotations PVC. Output is
+# served via nginx at /csv_archives/.
+#
+# Run via:
+#   oc apply -f deployment/shroff-data/10-job-csv-archives.yaml
+#
+# Re-running creates a new Job; the script itself skips datasets whose
+# archive already exists (set OVERWRITE=1 to force).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: gather-csv-archives-
+  namespace: shroff-data
+  labels:
+    app: shroff-data
+    component: gather-csv-archives
+spec:
+  backoffLimit: 0
+  # ~2 hours; CSV scanning + tar.gz is I/O-bound, mostly /nearline reads.
+  activeDeadlineSeconds: 7200
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app: shroff-data
+        component: gather-csv-archives
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: gather-csv-archives
+          image: image-registry.openshift-image-registry.svc:5000/shroff-data/shroff-data:latest
+          command:
+            - julia
+            - --project=/app/ShroffCelegansModels.jl/web
+            - /app/ShroffCelegansModels.jl/web/scripts/gather_csv_archives.jl
+          workingDir: /app/ShroffCelegansModels.jl
+          env:
+            - name: CSV_ARCHIVE_DIR
+              value: /data/annotations/csv_archives
+            # Set OVERWRITE=1 to force re-archive datasets whose archive exists.
+            - name: OVERWRITE
+              value: "0"
+          volumeMounts:
+            - name: nearline
+              mountPath: /nearline/shroff
+              readOnly: true
+            - name: annotations
+              mountPath: /data/annotations
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 250m
+            limits:
+              memory: 2Gi
+              cpu: "2"
+      volumes:
+        - name: nearline
+          persistentVolumeClaim:
+            claimName: shroff-data-nearline
+        - name: annotations
+          persistentVolumeClaim:
+            claimName: shroff-data-annotations

--- a/notes/trigger-recompute-pipeline.md
+++ b/notes/trigger-recompute-pipeline.md
@@ -1,0 +1,70 @@
+# Triggering the recompute pipeline manually
+
+The recompute pipeline normally runs via the `recompute-on-mtime-change`
+CronJob (daily at 03:00 ET, see `deployment/shroff-data-test/09-cronjob-recompute.yaml`).
+The CronJob runs `web/scripts/run_recompute_if_needed.jl`, which is a
+**conditional** entry point: it only executes the pipeline when one of these
+is true, otherwise it exits 0 and does nothing —
+
+1. a `pending_recompute` marker file exists at
+   `/data/annotations/modified_times/pending_recompute`, **or**
+2. `/data/annotations/annotation_changes.h5` is newer than the newest
+   top-level file in `/data/annotations/recompute/` (i.e. an annotation edit
+   landed since the last run).
+
+So creating a Job from the CronJob is **not** enough on its own — if neither
+condition holds, the job spins up Julia and immediately exits. To force a run
+you must first plant the marker.
+
+## Step-by-step (test namespace)
+
+`oc` is provided by the `deployment/` pixi env (it is not on PATH). Examples
+use the direct binary path; `cd deployment && pixi run oc …` works too.
+
+```bash
+OC=deployment/.pixi/envs/default/bin/oc
+NS=shroff-data-test
+
+# 1. Confirm login + project
+$OC whoami
+$OC project          # should be shroff-data-test
+
+# 2. Write the pending_recompute marker.
+#    The annotations PVC is mounted READ-ONLY in most containers of the web
+#    deployment pod. Use a container that mounts it READ-WRITE — zscore-analysis
+#    (or fix-ap-axis / debug-zscore) qualifies. The marker is JSON carrying the
+#    `kinds` the pipeline should recompute.
+POD=$($OC get pods -n $NS -l app=shroff-data-test -o name | head -1)
+$OC exec -n $NS -c zscore-analysis $POD -- sh -c \
+  'printf "%s" "{\"kinds\":[\"annotation\",\"lattice\"],\"reason\":\"manual_trigger\"}" \
+   > /data/annotations/modified_times/pending_recompute'
+
+# 3. Create a one-off Job from the CronJob (inherits N=371, --threads=16,
+#    resources, volume mounts from the CronJob's jobTemplate).
+$OC create job -n $NS --from=cronjob/recompute-on-mtime-change recompute-manual-$(date +%Y%m%d)
+
+# 4. Watch it
+$OC get pods -n $NS -l job-name=recompute-manual-$(date +%Y%m%d)
+$OC logs -f -n $NS <pod-name>
+```
+
+## Notes
+
+- **The script deletes the marker on success and leaves it on failure**, so a
+  failed run is automatically retried by the next CronJob tick. If you abandon
+  a manual run, remove the marker yourself or the next cron will re-trigger.
+- A cold-cache full `N=371` run can take **hours** (the CronJob's
+  `activeDeadlineSeconds` is 43200 = 12h). It archives the previous
+  `/data/annotations/recompute/` outputs into a timestamped `archive_*` dir,
+  then writes fresh averaged HDF5, CSVs, caches, the meshscatter HTML, and the
+  yz/xz movies.
+- For a faster validation run, override `N_TIMEPOINTS` (e.g. `51`). You can't
+  set env on `oc create job --from`, so either edit the CronJob's env first or
+  apply a one-off Job manifest with the override.
+- `concurrencyPolicy: Forbid` only governs CronJob-spawned jobs; a manually
+  created Job can still race a cron run on the shared
+  `/data/annotations/recompute/checkpoint/` dir. Check for a running
+  `recompute-on-mtime-change-*` pod before starting one (the cron schedule was
+  lowered to once-daily specifically to avoid this — see task #41).
+- **Production** (`shroff-data` namespace): substitute `NS=shroff-data` and the
+  production PVC/CronJob names accordingly.

--- a/scripts/export_meshscatter_static.jl
+++ b/scripts/export_meshscatter_static.jl
@@ -1,19 +1,331 @@
 using WGLMakie
 using Bonito
+using Makie
+using Printf
+using GeometryBasics
+using ShroffCelegansModels.CSV
+using ShroffCelegansModels.DataFrames: DataFrame, eachrow
 
-include(joinpath(@__DIR__, "meshscatter_average_simple.jl"))
+# ─────────────────────────────────────────────────────────────────────────────
+# Server-less interactive HTML export of the average-annotation meshscatter.
+#
+# A static export (Bonito.export_static) has NO Julia backend, so Makie `lift`
+# closures never run — a Makie.Slider would leave the scene frozen. Following
+# mkitti/BrownianMotionDemo.jl, we instead:
+#   • build the scene with STATIC positions (last timepoint),
+#   • drive time entirely in the browser with a native HTML `Bonito.Slider`
+#     (requires `use_html_widgets = true`),
+#   • on slider change, overwrite each meshscatter's GPU instance-position buffer
+#     (`positions_transformed_f32c`) via `onjs`, with every timepoint's flat Float32
+#     positions embedded at export time,
+#   • render the HPF label as a DOM overlay (animates via onjs AND stays visible
+#     through zoom, unlike in-scene text!).
+#
+# Layout follows the demo: a fixed-size Figure inside a centered, max-width flex
+# column — NOT resize_to=:body / 100vw, which overflows into a horizontal scrollbar.
+# This script is intentionally SELF-CONTAINED (it does not share the movie builder
+# meshscatter_average_simple.jl, which uses a Makie.Slider + lift for CairoMakie/
+# GLMakie recording).
+# ─────────────────────────────────────────────────────────────────────────────
 
-# Export a self-contained interactive HTML file via Bonito.export_static.
-# The resulting HTML embeds all WGLMakie JavaScript and cell-position data so
-# the time slider works in any browser without a Julia backend.
+# WGLMakie's internal flat Float32 instance-position GPU buffer for meshscatter.
+# Verified present in the pinned WGLMakie (plot-primitives.jl). If a WGLMakie bump
+# renames it, this is the single line to update.
+const POS_BUFFER_KEY = "positions_transformed_f32c"
+
+function _load_colors_dict()
+    colors_csv = joinpath(@__DIR__, "..", "colors.csv")
+    colors_dict = Dict{String, RGBf}()
+    colors_df = CSV.read(colors_csv, DataFrame)
+    for row in eachrow(colors_df)
+        colors_dict[lowercase(row.Annotation)] = RGBf(row.R/255, row.G/255, row.B/255)
+    end
+    return colors_dict
+end
+
+const _LEGEND_COLORS = RGBf[
+    RGBf(185,   0, 255),
+    RGBf(  0, 255, 255),
+    RGBf(255,   0,   0),
+    RGBf(255,  99,  93),
+    RGBf(  0,   0, 128),
+    RGBf(255, 251,  93),
+    RGBf( 16, 185,   0),
+    RGBf(  0, 128,   0),
+    RGBf( 93, 255, 109),
+] ./ 255
+const _LEGEND_TEXT = String[
+    "Neurons", "Neuroblast", "Muscle", "Intestine", "Nerve Ring",
+    "Glial", "Seam Cell", "Other Hypodermal", "Pharyngeal",
+]
+
 # avg_dict: Dict from load_latest_average_annotations()
 # output_path: destination .html file path
-function export_meshscatter_static(average_annotations_dict; output_path::String)
-    WGLMakie.activate!()
-    app = App(; title="C. elegans Average Annotations") do session::Session
+# view: :yz (default), :xz, or :xy
+# figure_size / max_width_px: the fixed figure size and the centered card cap.
+function export_meshscatter_static(average_annotations_dict;
+        output_path::String,
+        view::Symbol = :yz,
+        figure_size = (1536, 560),
+        max_width_px::Int = 1536)
+    # resize_to=:parent makes WGLMakie size the canvas to its parent element
+    # CLIENT-SIDE at setup (initialize_canvas_size), so it fills the container on
+    # first paint instead of coming up small until the first interaction. The parent
+    # (fig_box) must have a real height — supplied via aspect-ratio below.
+    WGLMakie.activate!(use_html_widgets = true, resize_to = :parent)
+
+    colors_dict = _load_colors_dict()
+    get_color(a) = get(colors_dict, lowercase(a), RGBAf(1, 1, 1, 1))
+
+    coordinates = values(average_annotations_dict)
+    time_points = axes(first(coordinates).positions, 1)
+    T = length(time_points)
+    t0 = first(time_points)
+    t_last = last(time_points)
+
+    # Initial HPF string (slider starts at the last timepoint). JS mirrors this formula.
+    _init_total = (t_last - 1 + 21) / (T - 1) * 370
+    _init_hpf = "hpf = $(6 + floor(Int, _init_total / 60)):$(lpad(floor(Int, mod(_init_total, 60)), 2, '0'))"
+
+    label_offset = 8
+    scalebar_size_um = 10
+    scalebar_y_offset = 180
+
+    app = App(; title = "C. elegans Average Annotations") do session::Session
         with_theme(theme_black()) do
-            fig, _ = meshscatter_average_simple(average_annotations_dict; xy_bounding_radius=sqrt(52))
-            DOM.body(fig, style=Styles(CSS("background-color" => "black")))
+            fig = Figure(size = figure_size)
+            ax = LScene(fig[1, 1]; show_axis = false)
+
+            # Native HTML slider (the "scrubber") — drives the animation client-side.
+            sg = Bonito.Slider(time_points, value = t_last)
+
+            # Static meshscatter per group; collect plot handle + per-timepoint flat
+            # Float32 positions (interleaved x,y,z) for the onjs buffer update.
+            # NOTE: explicit flatten — reinterpret(Float32, ::Vector{Point3{Float64}})
+            # is invalid (Float64→Float32 width mismatch). Rendered unfiltered so the
+            # point count is constant across timepoints (required: fixed-size GPU buffer).
+            plots = Any[]
+            group_positions = Vector{Vector{Float32}}[]
+            # uuid → per-point annotation names, for the client-side hover tooltip.
+            # js_uuid(plot) == string(objectid(plot)) matches the JS `plot_uuid`
+            # returned by WGL.pick_closest.
+            names_by_uuid = Dict{String, Vector{String}}()
+            for v in coordinates
+                cols = get_color.(v.annotations)
+                p = meshscatter!(ax, v.positions[t_last]; markersize = 1.0, color = cols,
+                    inspectable = true)
+                push!(plots, p)
+                names_by_uuid[WGLMakie.js_uuid(p)] = String.(v.annotations)
+                push!(group_positions,
+                      [Float32[c for pt in v.positions[t] for c in pt] for t in time_points])
+            end
+
+            # Animate positions client-side: on slider change, overwrite each group's
+            # GPU position buffer with that timepoint's embedded flat Float32 array.
+            for (p, perT) in zip(plots, group_positions)
+                onjs(session, sg.value, js"""(val) => {
+                    const data = $(perT);
+                    const t = Math.round(val) - $(t0);    // slider value -> 0-based index
+                    if (t < 0 || t >= data.length) return;
+                    $(p).then(plots => {
+                        plots[0].plot_object.update([[$(POS_BUFFER_KEY), new Float32Array(data[t])]]);
+                    });
+                }""")
+            end
+
+            # Scalebar LINE stays in data space (overdraw=true) so its length tracks
+            # zoom correctly. The LABEL is a DOM overlay (below) — in-scene text! in
+            # WGLMakie 3D is orientation-dependent (only readable from some angles),
+            # whereas a DOM label is always visible.
+            scale_str, scalebar = if view == :xy
+                ("$(scalebar_size_um ÷ 2) μm",
+                 Point3f[
+                     [label_offset+1,                        0, -label_offset-1],
+                     [label_offset+1 - scalebar_size_um/2,   0, -label_offset-1],
+                 ])
+            else
+                ("$scalebar_size_um μm",
+                 Point3f[
+                     [label_offset+1, scalebar_y_offset,                    -label_offset-1],
+                     [label_offset+1, scalebar_y_offset + scalebar_size_um, -label_offset-1],
+                 ])
+            end
+            lines!(ax, scalebar, color = :white, linewidth = 5, overdraw = true)
+
+            # Legend: a DOM overlay (built below) rather than a Makie Legend. A Makie
+            # legend is baked into the WGLMakie scene at export time and can't reflow on
+            # window resize in a static file; an HTML flex-wrap row reflows natively.
+
+            cc = Camera3D(ax.scene;
+                projectiontype = Makie.Orthographic,
+                lookat = Vec3d(0, 90, 0), eyeposition = Vec3d(60, 90, 0))
+            zoom!(ax.scene, 0.30)
+            if view == :yz
+                update_cam!(ax.scene, cc, 0, 0)
+            elseif view == :xz
+                update_cam!(ax.scene, cc, 0, π/2)
+            elseif view == :xy
+                update_cam!(ax.scene, cc, π/2, 0)
+            else
+                error("view must be :yz, :xz, or :xy; got $view")
+            end
+
+            # HPF label as an absolutely-positioned DOM overlay over the figure box:
+            # animates via onjs and never disappears under the 3D camera.
+            hpf = DOM.div(_init_hpf; id = "hpf-label", style = Styles(CSS(
+                "position" => "absolute", "top" => "10px", "left" => "14px",
+                "color" => "white", "font-size" => "20px",
+                "font-family" => "sans-serif", "z-index" => "10",
+                "pointer-events" => "none")))
+
+            # Scalebar label as a DOM overlay (always visible; pairs with the in-scene
+            # line). Top-right so it clears the bottom DOM legend.
+            scale_label = DOM.div("Scale Bar: $scale_str"; id = "scale-label", style = Styles(CSS(
+                "position" => "absolute", "top" => "10px", "right" => "14px",
+                "color" => "white", "font-size" => "18px",
+                "font-family" => "sans-serif", "z-index" => "10",
+                "pointer-events" => "none")))
+
+            # Legend as a DOM overlay across the bottom: an HTML flex-wrap row reflows
+            # natively as the window/figure width changes (a Makie legend can't, since
+            # it's frozen into the scene at export time). pointer-events:none so it never
+            # blocks camera interaction.
+            legend_items = map(zip(_LEGEND_COLORS, _LEGEND_TEXT)) do (c, label)
+                rgb = "rgb($(round(Int, 255*c.r)),$(round(Int, 255*c.g)),$(round(Int, 255*c.b)))"
+                DOM.span(
+                    DOM.span(""; style = Styles(CSS(
+                        "display" => "inline-block", "width" => "13px", "height" => "13px",
+                        "border-radius" => "50%", "background-color" => rgb,
+                        "margin-right" => "6px", "flex" => "0 0 auto"))),
+                    DOM.span(label);
+                    style = Styles(CSS("display" => "inline-flex", "align-items" => "center",
+                        "white-space" => "nowrap")))
+            end
+            legend = DOM.div(legend_items...; id = "legend", style = Styles(CSS(
+                "position" => "absolute", "bottom" => "6px", "left" => "0", "right" => "0",
+                "display" => "flex", "flex-wrap" => "wrap", "justify-content" => "center",
+                "align-items" => "center", "gap" => "4px 16px",
+                "padding" => "0 12px", "box-sizing" => "border-box",
+                "color" => "white", "font-family" => "sans-serif", "font-size" => "15px",
+                "z-index" => "10", "pointer-events" => "none")))
+            onjs(session, sg.value, js"""(val) => {
+                const T = $(T);
+                const t = Math.round(val);
+                const total = (t - 1 + 21) / (T - 1) * 370;
+                const hours = 6 + Math.floor(total / 60);
+                const minutes = Math.floor(total % 60);
+                const el = document.getElementById("hpf-label");
+                if (el) el.textContent = "hpf = " + hours + ":" + String(minutes).padStart(2, "0");
+            }""")
+
+            # DataInspector-style hover tooltip. The standard Makie DataInspector
+            # computes its label via a Julia callback on mouse events, which can't run
+            # in a server-less export. Instead we do the picking + label entirely
+            # client-side: on mousemove, WGL.pick_closest returns [plot_uuid, index];
+            # we look the annotation name up in the embedded uuid→names map and show a
+            # DOM tooltip at the cursor. position:fixed + clientX/Y keeps placement
+            # correct regardless of ancestor positioning/scroll.
+            tooltip = DOM.div(""; id = "inspector-tooltip", style = Styles(CSS(
+                "position" => "fixed", "display" => "none", "z-index" => "20",
+                "background" => "rgba(0,0,0,0.82)", "color" => "white",
+                "padding" => "4px 8px", "border-radius" => "4px",
+                "font-family" => "sans-serif", "font-size" => "14px",
+                "pointer-events" => "none", "white-space" => "nowrap")))
+            Bonito.evaljs(session, js"""
+                Promise.all([$(WGLMakie.WGL), $(ax.scene)]).then(([WGL, scene]) => {
+                    if (!scene || !scene.screen) { return; }
+                    const canvas = scene.screen.canvas;
+                    const lookup = $(names_by_uuid);
+                    const tip = $(tooltip);
+                    const POS_KEY = $(POS_BUFFER_KEY);
+                    canvas.addEventListener("mousemove", (event) => {
+                        const xy = WGL.events2unitless(scene.screen, event);
+                        // 1x1 pick: only fires when the cursor is actually over a point
+                        // (empty area -> picks.length == 0 -> hide), so no nearest-point
+                        // tooltip in blank space.
+                        const picked = WGL.pick_native(scene, xy[0], xy[1], 1, 1);
+                        if (picked) {
+                            const picks = picked[1];
+                            if (picks.length === 1) {
+                                const [plot, index] = picks[0];
+                                const names = lookup[plot.plot_uuid];
+                                if (names) {
+                                    const name = (names[index] !== undefined) ? names[index] : "?";
+                                    // Current coordinate straight from the GPU instance
+                                    // buffer (reflects the animated timepoint).
+                                    let coord = "";
+                                    const attr = plot.geometry.attributes[POS_KEY];
+                                    if (attr && attr.array) {
+                                        const a = attr.array;
+                                        const x = a[index*3], y = a[index*3+1], z = a[index*3+2];
+                                        coord = " (" + x.toFixed(1) + ", " + y.toFixed(1) + ", " + z.toFixed(1) + ")";
+                                    }
+                                    tip.innerText = name + coord;
+                                    tip.style.left = (event.clientX + 12) + "px";
+                                    tip.style.top  = (event.clientY + 12) + "px";
+                                    tip.style.display = "block";
+                                    return;
+                                }
+                            }
+                        }
+                        tip.style.display = "none";
+                    });
+                    canvas.addEventListener("mouseleave", () => { tip.style.display = "none"; });
+
+                    // Camera reconcile kick. In attach_3d_camera, the makie projection
+                    // is only rebuilt (update_matrices) from the OrbitControls "change"
+                    // handler — which never fires at load, so the plot renders with the
+                    // serialized projection until the first scroll/drag. The correct fix
+                    // is OrbitControls.update(): the SAME call scroll/drag make. It
+                    // reconciles the controls' spherical state with the camera and THEN
+                    // dispatches "change" (a bare dispatchEvent skips the reconciliation
+                    // and mis-frames the view). allow_update() is true in a server-less
+                    // export (no Julia), so this runs client-side. Fire across a few
+                    // frames to catch the settled canvas resolution.
+                    const recompute = () => {
+                        if (scene.orbitcontrols) { scene.orbitcontrols.update(); }
+                    };
+                    requestAnimationFrame(recompute);
+                    setTimeout(recompute, 50);
+                    setTimeout(recompute, 250);
+                    setTimeout(recompute, 600);
+                });
+            """)
+
+            # Centered, max-width flex column (demo pattern): no element exceeds the
+            # viewport width, so there is no horizontal scrollbar on any screen size.
+            # Anchor the overlays to the figure box (position:relative) so they sit in
+            # the figure's corners rather than the whole card.
+            fig_box = DOM.div(hpf, scale_label, legend, tooltip, fig; style = Styles(CSS(
+                "position" => "relative", "width" => "100%",
+                "aspect-ratio" => "$(figure_size[1]) / $(figure_size[2])")))
+
+            # Make the native range input stretch to fill its (flex) container.
+            slider_css = DOM.style("input[type=range]{width:100%; accent-color:#38bdf8; height:6px;}")
+            card = DOM.div(
+                slider_css, fig_box,
+                DOM.div(
+                    DOM.span("Time"; style = Styles(CSS(
+                        "color" => "#cbd5e1", "font-weight" => "700",
+                        "font-family" => "sans-serif", "font-size" => "0.95rem"))),
+                    DOM.div(sg; style = Styles(CSS("flex" => "1", "width" => "100%")));
+                    style = Styles(CSS("width" => "100%", "display" => "flex",
+                        "align-items" => "center", "gap" => "0.75rem"))),
+                style = Styles(CSS(
+                    "position" => "relative", "width" => "100%",
+                    "max-width" => "$(max_width_px)px",
+                    "display" => "flex", "flex-direction" => "column",
+                    "align-items" => "center", "gap" => "0.5rem")))
+
+            # Zero the default <html>/<body> margin and paint them black, otherwise the
+            # browser's default body margin shows as a white border around the card.
+            body_css = DOM.style("html,body{margin:0;padding:0;background-color:#000;}")
+
+            return DOM.div(body_css, card; style = Styles(CSS(
+                "min-height" => "100vh", "background-color" => "black",
+                "margin" => "0", "padding" => "1rem", "box-sizing" => "border-box",
+                "display" => "flex", "flex-direction" => "column",
+                "align-items" => "center")))
         end
     end
     Bonito.export_static(output_path, app)

--- a/scripts/meshscatter_average_simple.jl
+++ b/scripts/meshscatter_average_simple.jl
@@ -15,10 +15,12 @@ function load_colors_dict_simple()
     return colors_dict
 end
 
-# Stripped-down meshscatter visualization: time slider only, no record/cosmetic
-# controls. Uses lift() so Observable updates are serializable to JavaScript for
-# Bonito.export_static and also work with CairoMakie headless recording.
-# Returns (fig, time_slider).
+# Stripped-down meshscatter visualization for MOVIE generation (CairoMakie/GLMakie):
+# time slider only, no record/cosmetic controls. Uses lift() so the Observable graph
+# updates under headless Record. Returns (fig, time_slider, ax). This file stays
+# Bonito-free so the glmakie project (no Bonito dep) can include it. The server-less
+# HTML static export does NOT use this builder — see export_meshscatter_static.jl,
+# which builds its own scene with a Bonito.Slider + client-side onjs animation.
 function meshscatter_average_simple(average_annotations_dict;
         xy_bounding_radius = -1,
         figure_size = (960, 300),
@@ -74,8 +76,11 @@ function meshscatter_average_simple(average_annotations_dict;
     scalebar_label_position = lift(scalebar) do pos
         first(pos)
     end
-    text!(ax, scalebar_label_position; text = scalebar_text, fontsize = _fontsize, align = (:left, :bottom))
-    lines!(ax, scalebar, color = :white, linewidth = 5)
+    # overdraw=true disables depth testing so the scalebar (data-space) text + line
+    # survive zoom under the orthographic camera (otherwise glyphs clip out — issue #4).
+    text!(ax, scalebar_label_position; text = scalebar_text, fontsize = _fontsize,
+        align = (:left, :bottom), overdraw = true)
+    lines!(ax, scalebar, color = :white, linewidth = 5, overdraw = true)
 
     alpha_obs = Observable(1.0)
 

--- a/src/demo_averaging/average_annotations.jl
+++ b/src/demo_averaging/average_annotations.jl
@@ -6,7 +6,7 @@ using DataFrames
 using HDF5
 
 # include("get_group_annotation_positions_over_time.jl")
-using ShroffCelegansModels: CelegansModel, get_datasets_info, get_group_annotation_positions_over_time, annotation_positions
+using ShroffCelegansModels: CelegansModel, get_datasets_info, get_group_annotation_positions_over_time, annotation_positions, prime_dataset_positions!
 
 function average_annotations(
     datasets::Vector{ShroffCelegansModels.Datasets.NormalizedDataset};
@@ -63,14 +63,23 @@ function average_annotations(
     use_cell_key_annotations_only = true,
     checkpoint_dir::Union{Nothing, AbstractString} = nothing,
 )
-    # Shared progress state so every group's "step6 dataset done" line is
-    # numbered against the grand total of datasets across all groups, making
-    # overall progress estimable (otherwise each group restarts at 1/N).
-    grand_total = sum(length, values(datasets); init = 0)
-    progress_counter = Threads.Atomic{Int}(0)
+    if isa(timepoints, Integer)
+        timepoints = LinRange(0, 1, timepoints)
+    end
+
+    # Single flat, 16-wide pass over ALL datasets across ALL groups, filling the
+    # path-keyed `cache`. This is the parallel hot loop (previously the warp ran
+    # only ~3-wide per group); the per-group averaging below then runs entirely on
+    # cache hits. Numerically identical — the cache value IS the computed value.
+    grand_total = prime_dataset_positions!(datasets, cache, timepoints; avg_models, checkpoint_dir)
+
+    # The group loop now reads cache. Seed the counter at grand_total and pass it
+    # through: get_group sees a non-nothing counter ⇒ count_done=false ⇒ cache hits
+    # stay at @debug (no double-count). A genuine post-prime miss would log >grand_total.
+    progress_counter = Threads.Atomic{Int}(grand_total)
     group_keys = collect(keys(datasets))
     average_annotations_dict = Dict(group_keys .=> map(enumerate(group_keys)) do (gi, k)
-           @info "[6/8] Averaging group" group=k group_number=string(gi, "/", length(group_keys)) n_datasets=length(datasets[k]) datasets_done=progress_counter[] grand_total
+           @info "[6/8] Averaging group (cached)" group=k group_number=string(gi, "/", length(group_keys)) n_datasets=length(datasets[k]) grand_total
            average_annotations(datasets[k]; cache, timepoints, avg_models, use_cell_key_annotations_only, checkpoint_dir, progress_counter, progress_total=grand_total)
     end)
     return average_annotations_dict

--- a/src/demo_averaging/explicit_export.jl
+++ b/src/demo_averaging/explicit_export.jl
@@ -59,22 +59,30 @@ end
 """
     get_combined_explicit_df(; avg_models, ben_csv_path,
                              pretwitch_df = get_pretwitch_df(),
-                             annotation_name_translation_df = get_annotation_name_translation_df())
+                             annotation_name_translation_df = get_annotation_name_translation_df(),
+                             add_unsmoothed_seam_cells = false)
 
 Returns `(; pretwitch_explicit_df, posttwitch_for_ben_explicit_df, combined_df)`.
 
 - `pretwitch_explicit_df`: pretwitch coords aligned to the first avg_model frame.
 - `posttwitch_for_ben_explicit_df`: `_for_ben.csv` rows translated to
   the explicit schema, with positional names mapped to lineage names
-  via `annotation_name_translation_df`, plus the avg_model seam cells
-  appended.
+  via `annotation_name_translation_df`.
 - `combined_df`: vertical concatenation of the two.
+
+The `_for_ben.csv` already contains the seam cells (added to the averaged
+HDF5 as a `seam_cells` group and smoothed before export, then read back by
+`resave_for_ben`). Setting `add_unsmoothed_seam_cells = true` *additionally*
+appends the **unsmoothed** seam cells pulled directly from `avg_models` via
+`get_seam_cells_explicit_df`. That double-counts every seam cell (a smoothed
+copy and an unsmoothed copy per timepoint), so it defaults to `false`.
 """
 function get_combined_explicit_df(;
     avg_models,
     ben_csv_path::AbstractString,
     pretwitch_df::DataFrame = get_pretwitch_df(),
     annotation_name_translation_df::DataFrame = get_annotation_name_translation_df(),
+    add_unsmoothed_seam_cells::Bool = false,
 )
     pretwitch_explicit_df = get_pretwitch_explicit_df(pretwitch_df; avg_models)
 
@@ -91,10 +99,12 @@ function get_combined_explicit_df(;
         :z => :DV_micrometers,
         :y => :AP_micrometers,
     )
-    posttwitch_for_ben_explicit_df = vcat(
-        posttwitch_for_ben_explicit_df,
-        get_seam_cells_explicit_df(avg_models; positional_to_lineage_dict),
-    )
+    if add_unsmoothed_seam_cells
+        posttwitch_for_ben_explicit_df = vcat(
+            posttwitch_for_ben_explicit_df,
+            get_seam_cells_explicit_df(avg_models; positional_to_lineage_dict),
+        )
+    end
     subset!(posttwitch_for_ben_explicit_df, :lineage_name => ByRow(!ismissing))
 
     combined_df = vcat(pretwitch_explicit_df, posttwitch_for_ben_explicit_df)
@@ -128,6 +138,7 @@ function write_combined_explicit_csvs(;
     date_str::AbstractString = Dates.format(Dates.now(), "yyyy_mm_dd_HHMMSS"),
     pretwitch_df::DataFrame = get_pretwitch_df(),
     annotation_name_translation_df::DataFrame = get_annotation_name_translation_df(),
+    add_unsmoothed_seam_cells::Bool = false,
 )
     mkpath(output_dir)
     result = get_combined_explicit_df(;
@@ -135,6 +146,7 @@ function write_combined_explicit_csvs(;
         ben_csv_path = ben_csv_path,
         pretwitch_df = pretwitch_df,
         annotation_name_translation_df = annotation_name_translation_df,
+        add_unsmoothed_seam_cells = add_unsmoothed_seam_cells,
     )
     _p = isempty(prefix) ? "" : "$(prefix)_"
     pretwitch_path = joinpath(output_dir, "$(_p)pretwitch_$(date_str).csv")

--- a/src/demo_averaging/get_group_annotation_positions_over_time.jl
+++ b/src/demo_averaging/get_group_annotation_positions_over_time.jl
@@ -59,6 +59,159 @@ function annotation_positions(smts_nt, annotation_dict, nt; avg_models::Vector{<
     return positions
 end
 
+# Compute (or fetch from `cache`) one dataset's positions-over-time. This is the
+# per-dataset unit of work shared by the flat `prime_dataset_positions!` pass and
+# by `get_group_annotation_positions_over_time`'s loop, so the warp / cache-store /
+# checkpoint / log+count logic lives in exactly one place. Returns the raw
+# positions vector (the dict-wrapping for the averaging stays in the group caller).
+#
+# `count_done=false` is used by the post-prime group pass: on a cache hit it logs at
+# @debug and does NOT increment the counter, so a primed dataset isn't counted twice
+# (prime owns the count). With `count_done=true` (the prime pass and standalone
+# callers) every dataset is logged + counted exactly as the original loop did.
+function compute_dataset_positions!(
+    dataset_info,
+    cache::Dict{String, Vector{Vector{Point3{Float64}}}},
+    cache_lock::ReentrantLock,
+    normalized_timepoints::AbstractVector{Float64},
+    avg_models::Vector{<: CelegansModel},
+    checkpoint_dir::Union{Nothing, AbstractString};
+    done_counter::Threads.Atomic{Int},
+    grand_total::Int,
+    log_idx::Int = 0,
+    log_total::Int = grand_total,
+    count_done::Bool = true,
+)::Vector{Vector{Point3{Float64}}}
+    ds_t0 = time()
+    dataset = dataset_info.dataset
+    annotation_dict = dataset_info.annotation_dict
+    smts_nt = dataset_info.smts_nt
+
+    cached = lock(cache_lock) do
+        get(cache, dataset.path, nothing)
+    end
+    from_cache = cached !== nothing
+    positions = if from_cache
+        cached
+    else
+        local pos = Vector{Vector{Point3{Float64}}}(undef, length(normalized_timepoints))
+        # One TPS workspace per dataset (= per @threads task ⇒ thread-local),
+        # reused across this dataset's timepoints so the ~tens-of-MB solve buffers
+        # aren't re-allocated ~371× here. Lazily sized on first solve.
+        local ws = Ref{Any}(nothing)
+        for i in eachindex(normalized_timepoints)
+            pos[i] = annotation_positions(smts_nt, annotation_dict, normalized_timepoints[i]; avg_models, ws)
+        end
+        lock(cache_lock) do
+            cache[dataset.path] = pos
+        end
+        pos
+    end
+    positions::Vector{Vector{Point3{Float64}}}
+
+    # Write per-dataset checkpoint (skip cache hits — no point rewriting unchanged
+    # data). Each thread writes a unique filename so no lock is needed for the I/O.
+    checkpoint_bytes = if checkpoint_dir !== nothing && !from_cache
+        ShroffCelegansModels.write_dataset_checkpoint(checkpoint_dir, dataset.path, positions)
+    else
+        0
+    end
+
+    if from_cache && !count_done
+        @debug "step6 dataset cache hit (already primed)" path=dataset.path group_idx=log_idx
+    else
+        n_done = Threads.atomic_add!(done_counter, 1) + 1
+        @info("step6 dataset done",
+            dataset = string(n_done, "/", grand_total),
+            group_idx = log_idx,
+            group_total = log_total,
+            path = dataset.path,
+            thread = Threads.threadid(),
+            n_annotations = length(annotation_dict),
+            n_timepoints = length(normalized_timepoints),
+            elapsed_s = round(time() - ds_t0; digits=2),
+            from_cache = from_cache,
+            checkpoint_bytes = checkpoint_bytes,
+        )
+    end
+    return positions
+end
+
+# Pin BLAS to 1 thread for a Threads.@threads region and restore afterward. The
+# loop already parallelizes across all Julia threads, and each tps_solve! calls BLAS
+# (bunchkaufman); if BLAS also multithreads we get nthreads × blas_threads contending
+# for the same cores (on a 16-core pod: 16 Julia threads × a BLAS default of 50 ≈ 800
+# threads on a 16-core quota). With nthreads()==1 there is no Julia parallelism, so
+# leave BLAS as-is — a serial run still benefits from BLAS threads.
+function _scope_blas_for_threaded_region()
+    prev = LinearAlgebra.BLAS.get_num_threads()
+    region = Threads.nthreads() > 1 ? 1 : prev
+    LinearAlgebra.BLAS.set_num_threads(region)
+    return prev, region
+end
+
+# Flat, all-datasets-at-once priming pass. Today the averaging loop parallelizes only
+# over the ~3 datasets within one group (groups run sequentially), leaving a 16-core
+# pod ~half idle. The per-dataset warp is independent across ALL datasets and ALL
+# groups, and its output is the path-keyed `cache`, which the group pass already
+# short-circuits on. So flatten every group's datasets into one Threads.@threads loop
+# (16-wide) and fill the cache; the subsequent per-group averaging then runs entirely
+# on cache hits. No change to numerical output — the cache value IS the computed value.
+function prime_dataset_positions!(
+    datasets::Dict{String, Vector{ShroffCelegansModels.Datasets.NormalizedDataset}},
+    cache::Dict{String, Vector{Vector{Point3{Float64}}}},
+    normalized_timepoints::AbstractVector{Float64} = LinRange(0,1,201);
+    avg_models::Vector{<: CelegansModel} = avg_models,
+    checkpoint_dir::Union{Nothing, AbstractString} = nothing,
+)::Int
+    @assert length(avg_models) == length(normalized_timepoints)
+
+    # Flatten + dedupe by dataset.path (paths are group-independent; a duplicate
+    # would be identical, and the cache is keyed by path anyway).
+    seen = Set{String}()
+    all_datasets = ShroffCelegansModels.Datasets.NormalizedDataset[]
+    for k in keys(datasets), ds in datasets[k]
+        if !(ds.path in seen)
+            push!(seen, ds.path)
+            push!(all_datasets, ds)
+        end
+    end
+
+    # Model construction stays sequential (not run concurrently); only the warp is
+    # threaded. Time it so the serial head is visible in the logs.
+    @info "step6 prime: building datasets_info" n_datasets=length(all_datasets)
+    t_info = time()
+    datasets_info = get_datasets_info(all_datasets)
+    @info "step6 prime: datasets_info done" elapsed_s=round(time() - t_info; digits=2)
+
+    grand_total = length(datasets_info)
+    done_counter = Threads.Atomic{Int}(0)
+    cache_lock = ReentrantLock()
+    prog = ProgressMeter.Progress(grand_total; desc="Prime annotations / dataset...")
+
+    prev_blas, region_blas = _scope_blas_for_threaded_region()
+    @info("step6 prime: BLAS threads scoped for @threads region",
+        julia_nthreads = Threads.nthreads(),
+        blas_in_region = region_blas,
+        blas_prev = prev_blas,
+    )
+    try
+        Threads.@threads for ds_idx in eachindex(datasets_info)
+            compute_dataset_positions!(
+                datasets_info[ds_idx], cache, cache_lock, normalized_timepoints, avg_models, checkpoint_dir;
+                done_counter, grand_total,
+                log_idx = ds_idx, log_total = grand_total,
+                count_done = true,    # the prime pass is the authoritative counter
+            )
+            ProgressMeter.next!(prog)
+        end
+        ProgressMeter.finish!(prog)
+    finally
+        LinearAlgebra.BLAS.set_num_threads(prev_blas)
+    end
+    return grand_total
+end
+
 function get_group_annotation_positions_over_time(
     datasets::Vector{ShroffCelegansModels.Datasets.NormalizedDataset},
     cache::Dict{String, Vector{Vector{Point3{Float64}}}}, # my_annotation_position_cache
@@ -78,103 +231,49 @@ function get_group_annotation_positions_over_time(
     datasets_info = get_datasets_info(datasets)
     @info "get_datasets_info done" elapsed_s=round(time() - t_info; digits=2)
 
-    # Global progress numbering: when the caller (the Dict-keyed
-    # average_annotations) threads a shared counter + grand total through, each
-    # "step6 dataset done" line is numbered against ALL datasets across every
-    # group, so overall progress is estimable. Standalone calls fall back to
-    # this group's own dataset count.
+    # Global progress numbering: when the caller (the Dict-keyed average_annotations)
+    # threads a shared counter + grand total through, the cache has already been
+    # primed and the caller owns the count — so stay silent (@debug) on cache hits
+    # here to avoid double-counting (count_done=false). Standalone calls (no counter)
+    # fall back to this group's own dataset count and log every dataset.
     grand_total = progress_total === nothing ? length(datasets_info) : progress_total
     done_counter = progress_counter === nothing ? Threads.Atomic{Int}(0) : progress_counter
+    count_done = progress_counter === nothing
 
-    # Parallelize across datasets — the inner per-timepoint loop is replaced
-    # with a sequential map so we don't oversubscribe threads. Each dataset's
-    # work is independent except for the shared `cache` write, which is
-    # guarded by a lock.
     out = Vector{Vector{Dict{String, Point3{Float64}}}}(undef, length(datasets_info))
     cache_lock = ReentrantLock()
     prog = ProgressMeter.Progress(length(datasets_info); desc="Avg annotations / dataset...")
-    # Avoid BLAS-thread oversubscription inside this Threads.@threads region. The
-    # loop already parallelizes across all Julia threads, and each tps_solve! calls
-    # BLAS (bunchkaufman). If BLAS also multithreads we get nthreads × blas_threads
-    # contending for the same cores — on a 16-core pod we measured 16 Julia threads
-    # against a BLAS default of 50 (≈800 threads on a 16-core quota). Pin BLAS to 1
-    # for the region whenever Julia-thread parallelism is present, and restore it
-    # afterward. (With nthreads()==1 there is no Julia parallelism, so leave BLAS
-    # as-is — a serial run still benefits from BLAS threads.)
-    _prev_blas = LinearAlgebra.BLAS.get_num_threads()
-    _region_blas = Threads.nthreads() > 1 ? 1 : _prev_blas
-    LinearAlgebra.BLAS.set_num_threads(_region_blas)
+    prev_blas, region_blas = _scope_blas_for_threaded_region()
     @info("step6 BLAS threads scoped for @threads region",
         julia_nthreads = Threads.nthreads(),
-        blas_in_region = _region_blas,
-        blas_prev = _prev_blas,
+        blas_in_region = region_blas,
+        blas_prev = prev_blas,
     )
     try
     Threads.@threads for ds_idx in eachindex(datasets_info)
-        ds_t0 = time()
         dataset_info = datasets_info[ds_idx]
-        dataset = dataset_info.dataset
+        positions = compute_dataset_positions!(
+            dataset_info, cache, cache_lock, normalized_timepoints, avg_models, checkpoint_dir;
+            done_counter, grand_total,
+            log_idx = ds_idx, log_total = length(datasets_info),
+            count_done = count_done,
+        )
         annotation_dict = dataset_info.annotation_dict
-        smts_nt = dataset_info.smts_nt
-        cached = lock(cache_lock) do
-            get(cache, dataset.path, nothing)
-        end
-        from_cache = cached !== nothing
-        _annotation_positions_over_time = if from_cache
-            cached
-        else
-            local positions = Vector{Vector{Point3{Float64}}}(undef, length(normalized_timepoints))
-            # One TPS workspace per dataset (= per @threads task ⇒ thread-local),
-            # reused across this dataset's timepoints so the ~tens-of-MB solve
-            # buffers aren't re-allocated ~371× here. Lazily sized on first solve.
-            local ws = Ref{Any}(nothing)
-            for i in eachindex(normalized_timepoints)
-                positions[i] = annotation_positions(smts_nt, annotation_dict, normalized_timepoints[i]; avg_models, ws)
-            end
-            lock(cache_lock) do
-                cache[dataset.path] = positions
-            end
-            positions
-        end
-        _annotation_positions_over_time::Vector{Vector{Point3{Float64}}}
         out[ds_idx] = try
-            map(_annotation_positions_over_time) do points
+            map(positions) do points
                 Dict{String, Point3d}(keys(annotation_dict) .=> points)
             end
         catch err
-            @error "Error creating dict for dataset $(dataset.path)" exception = (err, Base.catch_backtrace())
-            map(_annotation_positions_over_time) do points
+            @error "Error creating dict for dataset $(dataset_info.dataset.path)" exception = (err, Base.catch_backtrace())
+            map(positions) do _points
                 Dict{String, Point3d}(keys(annotation_dict) .=> fill(Point3(NaN), length(keys(annotation_dict))))
             end
         end
-        # Write per-dataset checkpoint (skip if entry came from a prior checkpoint
-        # load — no point rewriting unchanged data). Each thread writes a unique
-        # filename so no lock is needed for the file I/O itself.
-        checkpoint_bytes = if checkpoint_dir !== nothing && !from_cache
-            ShroffCelegansModels.write_dataset_checkpoint(
-                checkpoint_dir, dataset.path, _annotation_positions_over_time,
-            )
-        else
-            0
-        end
-        n_done = Threads.atomic_add!(done_counter, 1) + 1
-        @info("step6 dataset done",
-            dataset = string(n_done, "/", grand_total),
-            group_idx = ds_idx,
-            group_total = length(datasets_info),
-            path = dataset.path,
-            thread = Threads.threadid(),
-            n_annotations = length(annotation_dict),
-            n_timepoints = length(normalized_timepoints),
-            elapsed_s = round(time() - ds_t0; digits=2),
-            from_cache = from_cache,
-            checkpoint_bytes = checkpoint_bytes,
-        )
         ProgressMeter.next!(prog)
     end
     ProgressMeter.finish!(prog)
     finally
-        LinearAlgebra.BLAS.set_num_threads(_prev_blas)
+        LinearAlgebra.BLAS.set_num_threads(prev_blas)
     end
     return out
 end

--- a/src/demo_averaging/resave_for_ben.jl
+++ b/src/demo_averaging/resave_for_ben.jl
@@ -47,7 +47,9 @@ function resave_for_ben(
     filename;
     target_filename = replace(filename, ".h5" => "_for_ben.csv"),
     time_range = (381, 751),
-    explicit::Bool = false
+    explicit::Bool = false,
+    canonicalize_cell_names::Bool = true,
+    annotation_name_translation_df::DataFrame = get_annotation_name_translation_df(),
 )
 
     if isfile(target_filename)
@@ -113,6 +115,18 @@ function resave_for_ben(
 
     # Convert to DataFrame (includes strain column)
     df_full = DataFrame(ben_data)
+
+    # Collapse case-variant positional names (e.g. RW10896's lowercase "P9/10l")
+    # onto the canonical name BEFORE the cross-strain average, so the variants are
+    # averaged together with equal per-strain weight instead of producing
+    # duplicate lineage rows downstream.
+    if canonicalize_cell_names
+        canon = canonical_cell_name_map(unique(df_full.cell); annotation_name_translation_df)
+        if !isempty(canon)
+            @info "Canonicalizing case-variant cell names before averaging" canon
+            df_full.cell = get.(Ref(canon), df_full.cell, df_full.cell)
+        end
+    end
 
     # Find cells that appear in multiple strains
     cells_per_strain = combine(groupby(df_full, [:cell, :time]), :strain => (x -> length(unique(x))) => :n_strains)

--- a/src/recompute_pipeline.jl
+++ b/src/recompute_pipeline.jl
@@ -268,7 +268,11 @@ function run_recompute_pipeline(;
     ben_csv = replace(h5_path, ".h5" => "_for_ben.csv")
     _phase("8/8 resave_for_ben") do
         @info "[8/8] Building intermediate _for_ben CSV (consumed by explicit export)" ben_csv
-        ShroffCelegansModels.resave_for_ben(h5_path; target_filename = ben_csv, time_range = (381, 751))
+        # Canonicalize case-variant positional names (e.g. P9/10l -> P9/10L) so
+        # the cross-strain average merges them with equal weight rather than
+        # leaving duplicate lineage rows in the explicit exports.
+        ShroffCelegansModels.resave_for_ben(h5_path; target_filename = ben_csv, time_range = (381, 751),
+            canonicalize_cell_names = true)
     end
 
     # 8a. Explicit-schema CSVs — the deliverables: `pretwitch_<ts>.csv`,

--- a/src/recompute_pipeline.jl
+++ b/src/recompute_pipeline.jl
@@ -284,6 +284,10 @@ function run_recompute_pipeline(;
                     avg_models = avg_models,
                     ben_csv_path = ben_csv,
                     date_str = ts,
+                    # Seam cells already arrive (smoothed) via the `seam_cells`
+                    # group in `_for_ben.csv`; don't re-append the unsmoothed
+                    # avg_models copies, which would double-count them.
+                    add_unsmoothed_seam_cells = false,
                 )
                 @info "[8a/8] Wrote explicit pretwitch/posttwitch/combined CSVs" res.pretwitch_path res.posttwitch_path res.combined_path
                 return (; res.pretwitch_path, res.posttwitch_path, res.combined_path)

--- a/src/seam_cell_to_lineage_map.jl
+++ b/src/seam_cell_to_lineage_map.jl
@@ -502,6 +502,70 @@ function get_annotation_name_translation_df(path::AbstractString = _NAMING_CORRE
     return CSV.read(path, DataFrame)
 end
 
+"""
+    canonical_cell_name_map(present_cells;
+        annotation_name_translation_df = get_annotation_name_translation_df())
+        -> Dict{String,String}
+
+Return a map from non-canonical positional cell names to their canonical form,
+for positional names that share an embryonic `Lineage Name` and are identical up
+to letter case. Only names appearing in `present_cells` are considered, and only
+lineages reached by more than one present name produce entries.
+
+The fully-uppercase variant is treated as canonical, e.g. `"P9/10l" => "P9/10L"`.
+Names with no case-variant collision are absent from the map; callers should fall
+back to the original name (`get(map, name, name)`).
+
+This lets the cross-strain average in [`resave_for_ben`](@ref) merge measurements
+recorded under case-variant labels (e.g. `RW10896`'s lowercase `P9/10l`) into one
+equally-weighted average, instead of leaving duplicate rows that both map to the
+same lineage downstream.
+"""
+function canonical_cell_name_map(
+    present_cells;
+    annotation_name_translation_df::DataFrame = get_annotation_name_translation_df(),
+)
+    pos2lin = Dict(
+        annotation_name_translation_df.var"Positional Model Cell Name" .=>
+        annotation_name_translation_df.var"Lineage Name",
+    )
+    present = Set(present_cells)
+
+    # lineage => present positional names mapping to it
+    lineage_to_names = Dict{String, Vector{String}}()
+    for c in present
+        l = get(pos2lin, c, missing)
+        ismissing(l) && continue
+        push!(get!(lineage_to_names, l, String[]), c)
+    end
+
+    canon = Dict{String, String}()
+    for (lineage, names) in lineage_to_names
+        length(names) > 1 || continue
+        # sub-group the colliding names by their uppercased form; only merge
+        # within a case-insensitive group.
+        by_upper = Dict{String, Vector{String}}()
+        for n in names
+            push!(get!(by_upper, uppercase(n), String[]), n)
+        end
+        merged_any = false
+        for (up, variants) in by_upper
+            length(variants) > 1 || continue
+            merged_any = true
+            # prefer the fully-uppercase variant if present, else the uppercased string
+            idx = findfirst(v -> v == uppercase(v), variants)
+            canonical = idx === nothing ? up : variants[idx]
+            for v in variants
+                v == canonical || (canon[v] = canonical)
+            end
+        end
+        if !merged_any
+            @warn "Lineage reached by multiple positional names that are not case-variants; not merging" lineage names
+        end
+    end
+    return canon
+end
+
 function get_color_code_df(path::AbstractString = _COLOR_CODE_CSV)
     return CSV.read(path, DataFrame)
 end

--- a/test/flat_prime.jl
+++ b/test/flat_prime.jl
@@ -1,0 +1,32 @@
+# Guards the flat step-6 priming refactor (prime_dataset_positions!). A full
+# numerical-equivalence test needs the /nearline dataset+annotation data that only
+# exists on the cluster (verified there via an HDF5 diff against a baseline). What we
+# CAN check locally without that data: the function is callable with the documented
+# signature, the empty-input path is a clean no-op, and the in-region BLAS thread
+# count is restored afterward (the `finally` invariant — important because the pad
+# loop pins BLAS to 1 while running).
+using LinearAlgebra
+using GeometryBasics: Point3
+
+@testset "prime_dataset_positions! empty input + BLAS restore" begin
+    lattice = joinpath(@__DIR__, "fixtures", "lattice.csv")
+    model = ShroffCelegansModels.build_celegans_model(lattice)
+    avg_models = [model, model, model]            # length must match timepoints
+    timepoints = LinRange(0, 1, 3)
+
+    cache = Dict{String, Vector{Vector{Point3{Float64}}}}()
+    empty_datasets = Dict{String, Vector{ShroffCelegansModels.Datasets.NormalizedDataset}}()
+
+    blas_before = BLAS.get_num_threads()
+    grand_total = ShroffCelegansModels.prime_dataset_positions!(
+        empty_datasets, cache, timepoints; avg_models,
+    )
+    @test grand_total == 0                         # no datasets ⇒ nothing primed
+    @test isempty(cache)                           # cache untouched
+    @test BLAS.get_num_threads() == blas_before    # restored in finally
+
+    # Timepoints/avg_models length mismatch is rejected.
+    @test_throws AssertionError ShroffCelegansModels.prime_dataset_positions!(
+        empty_datasets, cache, LinRange(0, 1, 5); avg_models,
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,5 @@ using Test
     include("annotation_cache.jl")
     include("avg_models.jl")
     include("transform_annotations.jl")
+    include("flat_prime.jl")
 end

--- a/web/scripts/web_zscore_analysis.jl
+++ b/web/scripts/web_zscore_analysis.jl
@@ -10,11 +10,50 @@ end
 include("../../scripts/launch_show_average_annotations.jl")
 include("../../src/demo_averaging/zscore_analysis.jl")
 
-function web_zscore_analysis(datasets = datasets)
-    @info "Loading annotation changes"
-    annotation_changes = ShroffCelegansModels.load_annotation_changes_cache()
-    ShroffCelegansModels.update_annotations_cache(ShroffCelegansModels.annotations_cache, annotation_changes);
-    @info "Loaded annotation changes"
+"""
+    web_zscore_analysis(datasets = datasets; apply_changes = true)
+
+Serve the z-score outlier table.
+
+The score is computed from `annotations_cache` (via `raw_annotation_dict` →
+`load_straightened_annotations_over_time`). For edits to be reflected, the cache
+must be (1) primed for every dataset so `update_annotations_cache` has keys to
+update, then (2) updated with the live annotation changes. Without priming, the
+update applies to an empty cache (every change is skipped) and the table scores
+raw, unedited positions.
+
+`apply_changes = true` (default) primes from the recompute output (which already
+has the last run's edits baked in) and then re-applies the live
+`annotation_changes.h5` so edits made since the last recompute are included.
+Set `apply_changes = false` to score only the recompute pipeline's end-of-run
+state (the primed cache) without layering the most recent changes on top.
+"""
+function web_zscore_analysis(datasets = datasets; apply_changes::Bool = true)
+    # Prime annotations_cache from the freshest available HDF5 (recompute PVC
+    # output, else baked-in snapshot), then map any legacy Windows-rooted keys
+    # to the Linux dataset.path. Mirrors web_show_average_annotations.jl.
+    @info "Priming annotation caches"
+    ShroffCelegansModels.prime_annotation_caches()
+    alias_cache_unix("/nearline/shroff/")
+    # Ensure every dataset is present as a cache key before applying changes —
+    # update_annotations_cache only mutates existing entries (recompute phase 2).
+    for group in values(datasets)
+        for dataset in values(group)
+            try
+                ShroffCelegansModels.load_straightened_annotations_over_time(dataset; use_myuntwist = true)
+            catch err
+                @warn "Cache prime failed for dataset" path = dataset.path err
+            end
+        end
+    end
+    if apply_changes
+        @info "Loading annotation changes"
+        annotation_changes = ShroffCelegansModels.load_annotation_changes_cache()
+        ShroffCelegansModels.update_annotations_cache(ShroffCelegansModels.annotations_cache, annotation_changes);
+        @info "Loaded annotation changes"
+    else
+        @info "Skipping annotation changes (apply_changes = false); scoring primed cache only"
+    end
     shroff_data_ip = "0.0.0.0"
     server = Server(
         shroff_data_ip, 9300;


### PR DESCRIPTION
Stacked on top of `annotations-cache-mtime`.

- **Step 6**: flat 16-wide priming across all datasets.
- Rework static meshscatter export to be **interactive and server-less**.
- Prepare **production manifests** for recompute-pipeline parity; nginx redirect/`absolute_redirect` fixes behind the TLS router.
- **Stop double-counting seam cells** in posttwitch/combined CSVs; merge case-variant cell names before cross-strain averaging.
- `web_zscore_analysis`: prime caches before applying annotation changes.
- Notes: how to manually trigger the recompute pipeline.

> Base is `annotations-cache-mtime` (PR #1 of the stack); GitHub will retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)