### PR TITLE
Pretwitch embryo orientation axes and central-spline/body-surface construction

### DIFF
--- a/pretwitch_orientation.txt
+++ b/pretwitch_orientation.txt
@@ -1,0 +1,29 @@
+We need to determine the anterior-posterior, dorsal-central, and left-right axes for the pretwitch embyro.
+
+We previously plotted pretwitch and posttwitch data in src/seam_cell_to_lineage_map.jl
+
+At the four cell state, we can establish the anterior-posterior and dorsal-ventral axis directions using these for reference.
+
+ABa - anterior
+ABp - dorsal
+P2 - posterior
+EMS - ventral
+
+After establishing the initial orientation, we need to determine the orientaion in subsequence frames. The first scheme to track the orientation is to use the following information from WormGuides. I understand that it uses the following data to interpolate a rotation of the axes.
+
+Column
+Value
+Key_Frames_Rotate
+1 16 321 359
+Key_Values_Rotate
+90 30 30 90
+Initial_Rotation
+0 0 0
+
+So the compass rotates 90°→30° between time points 1–16, holds at 30° through 321, then rotates back 30°→90° between 321–359 (out of 360 total time points).
+
+What I would like to do is make a movie of the pretwitch cell locations with the anterior-posterior, dorsal-ventral, and left-right axes labeled and then rotate the axes as described above. The goal is to establish these axes for every pretwitch frame and then rotate the pretwitch coordinates so that the three axes are fixed in place.
+
+1. I am not sure if the above interpolation scheme will work, but we should try it first.
+2. My next approach would be look at the lineage of the initial four cells, find the average position of the descendants, and then use those as markers in later frames.
+3. My last approach includes also using some post-twitch knowledge and the orientation analysis that we recently did to help establish the axes in the pretwitch embyro.

--- a/scripts/movie_pretwitch_axes_regression.jl
+++ b/scripts/movie_pretwitch_axes_regression.jl
@@ -1,0 +1,165 @@
+using CairoMakie
+using ShroffCelegansModels
+using ShroffCelegansModels: get_pretwitch_df, get_pretwitch_points_at_time,
+    pretwitch_reference_axes, pretwitch_cells_by_name, Point3f, Vec3f, normalize, dot, cross
+
+# Apply the regression weights from scripts/regress_pretwitch_axis_weights.jl
+# (pretwitch_axis_regression_weights.csv) to reconstruct DV/LR axes at every
+# pretwitch frame as a weighted combination of ~1300 individual cells'
+# directions from the body centroid, instead of Approach 1's WormGuides
+# compass interpolation. AP stays Approach 1's fixed four-cell-stage axis
+# (the regression didn't touch AP); the regression's dv/lr predictions are
+# Gram-Schmidt-orthogonalized against it to form a clean display frame.
+#
+# Cells are colored by their fitted regression weight (top row: dv_weight,
+# bottom row: lr_weight) on a diverging colormap fixed across the whole
+# movie -- this is what actually pulls the DV/LR arrows where they point,
+# so seeing which cells are strongly (and oppositely) weighted makes the
+# reconstruction legible rather than a black box.
+
+pretwitch_df = get_pretwitch_df()
+ref = pretwitch_reference_axes(pretwitch_df)
+grouped = pretwitch_cells_by_name(pretwitch_df)
+times = sort(unique(pretwitch_df.time))
+
+println("Precomputing per-frame centroid...")
+centroid_of = Dict{Int,Point3f}()
+for t in times
+    pts = collect(values(get_pretwitch_points_at_time(pretwitch_df, t)))
+    centroid_of[t] = Point3f(sum(pts) / length(pts))
+end
+
+const MIN_DIST = 10f0
+norm3(v) = sqrt(sum(abs2, v))
+
+println("Building raw (un-spliced) direction tracks...")
+dir_tracks = Dict{String,Dict{Int,Vector{Float64}}}()
+for (name, rows) in grouped
+    d = Dict{Int,Vector{Float64}}()
+    for (t, p) in rows
+        v = p - centroid_of[t]
+        norm3(v) < MIN_DIST && continue
+        d[t] = Float64.(normalize(v))
+    end
+    isempty(d) || (dir_tracks[name] = d)
+end
+
+println("Loading regression weights...")
+csv_path = joinpath(@__DIR__, "..", "pretwitch_axis_regression_weights.csv")
+dv_w = Dict{String,Float64}()
+lr_w = Dict{String,Float64}()
+open(csv_path) do io
+    readline(io)  # header
+    for line in eachline(io)
+        parts = split(line, ',')
+        name = parts[1]
+        dv_w[name] = parse(Float64, parts[3])
+        lr_w[name] = parse(Float64, parts[4])
+    end
+end
+println("$(length(dv_w)) weighted cells loaded.")
+
+const DV_MAX = maximum(abs, values(dv_w))
+const LR_MAX = maximum(abs, values(lr_w))
+const DIVERGING_CMAP = :RdBu
+
+function reconstruct(weights, t)
+    pred = zeros(3)
+    for (name, w) in weights
+        d = get(dir_tracks, name, nothing)
+        isnothing(d) && continue
+        p = get(d, t, nothing)
+        isnothing(p) && continue
+        pred .+= w .* p
+    end
+    nrm = norm3(pred)
+    return nrm < 1e-8 ? nothing : Vec3f(pred ./ nrm)
+end
+
+frame_data = map(times) do t
+    pts_dict = get_pretwitch_points_at_time(pretwitch_df, t)
+    names = collect(keys(pts_dict))
+    pts = collect(values(pts_dict))
+    centroid = centroid_of[t]
+
+    ap = ref.ap
+    dv_raw = reconstruct(dv_w, t)
+    lr_raw = reconstruct(lr_w, t)
+    dv = normalize(dv_raw - dot(dv_raw, ap) * ap)
+    lr_candidate = normalize(cross(ap, dv))
+    lr = dot(lr_candidate, lr_raw) < 0 ? -lr_candidate : lr_candidate
+
+    stabilized = [Point3f(dot(p - centroid, ap), dot(p - centroid, lr), dot(p - centroid, dv)) for p in pts]
+    dv_colors = [get(dv_w, name, 0.0) for name in names]
+    lr_colors = [get(lr_w, name, 0.0) for name in names]
+
+    (t=t, pts=pts, centroid=centroid, ap=ap, dv=dv, lr=lr, stabilized=stabilized,
+     dv_colors=dv_colors, lr_colors=lr_colors)
+end
+
+fig = Figure(size=(1500, 1300))
+
+ax_raw_dv = Axis3(fig[1, 1], title="raw, colored by dv_weight", aspect=:data,
+    limits=(50, 350, 20, 220, 40, 240))
+ax_stab_dv = Axis3(fig[1, 2], title="stabilized, colored by dv_weight", aspect=:data,
+    limits=(-150, 150, -150, 150, -150, 150), xlabel="AP", ylabel="LR", zlabel="DV")
+ax_raw_lr = Axis3(fig[2, 1], title="raw, colored by lr_weight", aspect=:data,
+    limits=(50, 350, 20, 220, 40, 240))
+ax_stab_lr = Axis3(fig[2, 2], title="stabilized, colored by lr_weight", aspect=:data,
+    limits=(-150, 150, -150, 150, -150, 150), xlabel="AP", ylabel="LR", zlabel="DV")
+
+pts_obs = Observable(frame_data[1].pts)
+stab_obs = Observable(frame_data[1].stabilized)
+dv_color_obs = Observable(frame_data[1].dv_colors)
+lr_color_obs = Observable(frame_data[1].lr_colors)
+
+scatter!(ax_raw_dv, pts_obs, color=dv_color_obs, colormap=DIVERGING_CMAP, colorrange=(-DV_MAX, DV_MAX), markersize=8)
+scatter!(ax_stab_dv, stab_obs, color=dv_color_obs, colormap=DIVERGING_CMAP, colorrange=(-DV_MAX, DV_MAX), markersize=8)
+scatter!(ax_raw_lr, pts_obs, color=lr_color_obs, colormap=DIVERGING_CMAP, colorrange=(-LR_MAX, LR_MAX), markersize=8)
+scatter!(ax_stab_lr, stab_obs, color=lr_color_obs, colormap=DIVERGING_CMAP, colorrange=(-LR_MAX, LR_MAX), markersize=8)
+
+Colorbar(fig[1, 3], colormap=DIVERGING_CMAP, colorrange=(-DV_MAX, DV_MAX), label="dv_weight")
+Colorbar(fig[2, 3], colormap=DIVERGING_CMAP, colorrange=(-LR_MAX, LR_MAX), label="lr_weight")
+
+arrow_scale = 60f0
+ap_obs = Observable([frame_data[1].centroid, frame_data[1].centroid + arrow_scale * frame_data[1].ap])
+dv_obs = Observable([frame_data[1].centroid, frame_data[1].centroid + arrow_scale * frame_data[1].dv])
+lr_obs = Observable([frame_data[1].centroid, frame_data[1].centroid + arrow_scale * frame_data[1].lr])
+
+for ax in (ax_raw_dv, ax_raw_lr)
+    lines!(ax, ap_obs, color=:black, linewidth=4)
+    lines!(ax, dv_obs, color=:black, linewidth=4, linestyle=:dash)
+    lines!(ax, lr_obs, color=:black, linewidth=4, linestyle=:dot)
+end
+for ax in (ax_stab_dv, ax_stab_lr)
+    lines!(ax, [Point3f(0,0,0), Point3f(arrow_scale,0,0)], color=:black, linewidth=4)
+    lines!(ax, [Point3f(0,0,0), Point3f(0,arrow_scale,0)], color=:black, linewidth=4, linestyle=:dot)
+    lines!(ax, [Point3f(0,0,0), Point3f(0,0,arrow_scale)], color=:black, linewidth=4, linestyle=:dash)
+end
+
+Legend(fig[1:2, 4],
+    [LineElement(color=:black, linewidth=4), LineElement(color=:black, linewidth=4, linestyle=:dash), LineElement(color=:black, linewidth=4, linestyle=:dot)],
+    ["AP (Approach 1, fixed)", "DV (regression weighted sum)", "LR (regression weighted sum)"],
+    "Legend")
+
+title_obs = Observable("t=$(frame_data[1].t)  (regression-weighted axes, cells colored by fitted weight)")
+Label(fig[0, 1:4], title_obs, fontsize=20, tellwidth=false)
+
+snapshot_indices = Set([1, 91, 181, 271, 361])
+
+outpath = joinpath(@__DIR__, "..", "pretwitch_axes_regression.mp4")
+record(fig, outpath, eachindex(frame_data); framerate=24) do i
+    d = frame_data[i]
+    pts_obs[] = d.pts
+    stab_obs[] = d.stabilized
+    dv_color_obs[] = d.dv_colors
+    lr_color_obs[] = d.lr_colors
+    ap_obs[] = [d.centroid, d.centroid + arrow_scale * d.ap]
+    dv_obs[] = [d.centroid, d.centroid + arrow_scale * d.dv]
+    lr_obs[] = [d.centroid, d.centroid + arrow_scale * d.lr]
+    title_obs[] = "t=$(d.t)  (regression-weighted axes, cells colored by fitted weight)"
+    if i in snapshot_indices
+        save(joinpath(@__DIR__, "..", "pretwitch_axes_regression_frame$(lpad(i, 3, '0')).png"), fig)
+    end
+end
+println("wrote $outpath")

--- a/scripts/movie_pretwitch_axes_regression_perframe.jl
+++ b/scripts/movie_pretwitch_axes_regression_perframe.jl
@@ -1,0 +1,166 @@
+using CairoMakie
+using ShroffCelegansModels
+using ShroffCelegansModels: get_pretwitch_df, get_pretwitch_points_at_time,
+    pretwitch_reference_axes, pretwitch_cells_by_name, Point3f, Vec3f, normalize, dot, cross
+
+# Same reconstruction as movie_pretwitch_axes_regression.jl (see that file for
+# the full explanation), but with the color scale renormalized EVERY FRAME to
+# that frame's own active-cell weight range, instead of held fixed to the
+# global max across all 361 frames. Trade-off: more visual contrast within
+# any single frame (useful since most individual cells have small weight
+# relative to the handful of dominant early lineage nodes -- see the fixed-
+# scale version, where most points look pale after those nodes divide away),
+# at the cost of the colorbar no longer meaning the same absolute weight
+# value from frame to frame.
+
+pretwitch_df = get_pretwitch_df()
+ref = pretwitch_reference_axes(pretwitch_df)
+grouped = pretwitch_cells_by_name(pretwitch_df)
+times = sort(unique(pretwitch_df.time))
+
+println("Precomputing per-frame centroid...")
+centroid_of = Dict{Int,Point3f}()
+for t in times
+    pts = collect(values(get_pretwitch_points_at_time(pretwitch_df, t)))
+    centroid_of[t] = Point3f(sum(pts) / length(pts))
+end
+
+const MIN_DIST = 10f0
+norm3(v) = sqrt(sum(abs2, v))
+
+println("Building raw (un-spliced) direction tracks...")
+dir_tracks = Dict{String,Dict{Int,Vector{Float64}}}()
+for (name, rows) in grouped
+    d = Dict{Int,Vector{Float64}}()
+    for (t, p) in rows
+        v = p - centroid_of[t]
+        norm3(v) < MIN_DIST && continue
+        d[t] = Float64.(normalize(v))
+    end
+    isempty(d) || (dir_tracks[name] = d)
+end
+
+println("Loading regression weights...")
+csv_path = joinpath(@__DIR__, "..", "pretwitch_axis_regression_weights.csv")
+dv_w = Dict{String,Float64}()
+lr_w = Dict{String,Float64}()
+open(csv_path) do io
+    readline(io)  # header
+    for line in eachline(io)
+        parts = split(line, ',')
+        name = parts[1]
+        dv_w[name] = parse(Float64, parts[3])
+        lr_w[name] = parse(Float64, parts[4])
+    end
+end
+println("$(length(dv_w)) weighted cells loaded.")
+
+const DIVERGING_CMAP = :RdBu
+const MIN_RANGE = 1e-3  # floor so a frame with near-zero weights doesn't blow up the color scale
+
+function reconstruct(weights, t)
+    pred = zeros(3)
+    for (name, w) in weights
+        d = get(dir_tracks, name, nothing)
+        isnothing(d) && continue
+        p = get(d, t, nothing)
+        isnothing(p) && continue
+        pred .+= w .* p
+    end
+    nrm = norm3(pred)
+    return nrm < 1e-8 ? nothing : Vec3f(pred ./ nrm)
+end
+
+frame_data = map(times) do t
+    pts_dict = get_pretwitch_points_at_time(pretwitch_df, t)
+    names = collect(keys(pts_dict))
+    pts = collect(values(pts_dict))
+    centroid = centroid_of[t]
+
+    ap = ref.ap
+    dv_raw = reconstruct(dv_w, t)
+    lr_raw = reconstruct(lr_w, t)
+    dv = normalize(dv_raw - dot(dv_raw, ap) * ap)
+    lr_candidate = normalize(cross(ap, dv))
+    lr = dot(lr_candidate, lr_raw) < 0 ? -lr_candidate : lr_candidate
+
+    stabilized = [Point3f(dot(p - centroid, ap), dot(p - centroid, lr), dot(p - centroid, dv)) for p in pts]
+    dv_colors = [get(dv_w, name, 0.0) for name in names]
+    lr_colors = [get(lr_w, name, 0.0) for name in names]
+    dv_range = max(maximum(abs, dv_colors), MIN_RANGE)
+    lr_range = max(maximum(abs, lr_colors), MIN_RANGE)
+
+    (t=t, pts=pts, centroid=centroid, ap=ap, dv=dv, lr=lr, stabilized=stabilized,
+     dv_colors=dv_colors, lr_colors=lr_colors, dv_range=dv_range, lr_range=lr_range)
+end
+
+fig = Figure(size=(1500, 1300))
+
+ax_raw_dv = Axis3(fig[1, 1], title="raw, colored by dv_weight (per-frame scale)", aspect=:data,
+    limits=(50, 350, 20, 220, 40, 240))
+ax_stab_dv = Axis3(fig[1, 2], title="stabilized, colored by dv_weight (per-frame scale)", aspect=:data,
+    limits=(-150, 150, -150, 150, -150, 150), xlabel="AP", ylabel="LR", zlabel="DV")
+ax_raw_lr = Axis3(fig[2, 1], title="raw, colored by lr_weight (per-frame scale)", aspect=:data,
+    limits=(50, 350, 20, 220, 40, 240))
+ax_stab_lr = Axis3(fig[2, 2], title="stabilized, colored by lr_weight (per-frame scale)", aspect=:data,
+    limits=(-150, 150, -150, 150, -150, 150), xlabel="AP", ylabel="LR", zlabel="DV")
+
+pts_obs = Observable(frame_data[1].pts)
+stab_obs = Observable(frame_data[1].stabilized)
+dv_color_obs = Observable(frame_data[1].dv_colors)
+lr_color_obs = Observable(frame_data[1].lr_colors)
+dv_colorrange_obs = Observable((-frame_data[1].dv_range, frame_data[1].dv_range))
+lr_colorrange_obs = Observable((-frame_data[1].lr_range, frame_data[1].lr_range))
+
+scatter!(ax_raw_dv, pts_obs, color=dv_color_obs, colormap=DIVERGING_CMAP, colorrange=dv_colorrange_obs, markersize=8)
+scatter!(ax_stab_dv, stab_obs, color=dv_color_obs, colormap=DIVERGING_CMAP, colorrange=dv_colorrange_obs, markersize=8)
+scatter!(ax_raw_lr, pts_obs, color=lr_color_obs, colormap=DIVERGING_CMAP, colorrange=lr_colorrange_obs, markersize=8)
+scatter!(ax_stab_lr, stab_obs, color=lr_color_obs, colormap=DIVERGING_CMAP, colorrange=lr_colorrange_obs, markersize=8)
+
+Colorbar(fig[1, 3], colormap=DIVERGING_CMAP, colorrange=dv_colorrange_obs, label="dv_weight (this frame)")
+Colorbar(fig[2, 3], colormap=DIVERGING_CMAP, colorrange=lr_colorrange_obs, label="lr_weight (this frame)")
+
+arrow_scale = 60f0
+ap_obs = Observable([frame_data[1].centroid, frame_data[1].centroid + arrow_scale * frame_data[1].ap])
+dv_obs = Observable([frame_data[1].centroid, frame_data[1].centroid + arrow_scale * frame_data[1].dv])
+lr_obs = Observable([frame_data[1].centroid, frame_data[1].centroid + arrow_scale * frame_data[1].lr])
+
+for ax in (ax_raw_dv, ax_raw_lr)
+    lines!(ax, ap_obs, color=:black, linewidth=4)
+    lines!(ax, dv_obs, color=:black, linewidth=4, linestyle=:dash)
+    lines!(ax, lr_obs, color=:black, linewidth=4, linestyle=:dot)
+end
+for ax in (ax_stab_dv, ax_stab_lr)
+    lines!(ax, [Point3f(0,0,0), Point3f(arrow_scale,0,0)], color=:black, linewidth=4)
+    lines!(ax, [Point3f(0,0,0), Point3f(0,arrow_scale,0)], color=:black, linewidth=4, linestyle=:dot)
+    lines!(ax, [Point3f(0,0,0), Point3f(0,0,arrow_scale)], color=:black, linewidth=4, linestyle=:dash)
+end
+
+Legend(fig[1:2, 4],
+    [LineElement(color=:black, linewidth=4), LineElement(color=:black, linewidth=4, linestyle=:dash), LineElement(color=:black, linewidth=4, linestyle=:dot)],
+    ["AP (Approach 1, fixed)", "DV (regression weighted sum)", "LR (regression weighted sum)"],
+    "Legend")
+
+title_obs = Observable("t=$(frame_data[1].t)  (regression-weighted axes, per-frame color scale)")
+Label(fig[0, 1:4], title_obs, fontsize=20, tellwidth=false)
+
+snapshot_indices = Set([1, 91, 181, 271, 361])
+
+outpath = joinpath(@__DIR__, "..", "pretwitch_axes_regression_perframe.mp4")
+record(fig, outpath, eachindex(frame_data); framerate=24) do i
+    d = frame_data[i]
+    pts_obs[] = d.pts
+    stab_obs[] = d.stabilized
+    dv_color_obs[] = d.dv_colors
+    lr_color_obs[] = d.lr_colors
+    dv_colorrange_obs[] = (-d.dv_range, d.dv_range)
+    lr_colorrange_obs[] = (-d.lr_range, d.lr_range)
+    ap_obs[] = [d.centroid, d.centroid + arrow_scale * d.ap]
+    dv_obs[] = [d.centroid, d.centroid + arrow_scale * d.dv]
+    lr_obs[] = [d.centroid, d.centroid + arrow_scale * d.lr]
+    title_obs[] = "t=$(d.t)  (regression-weighted axes, per-frame color scale)"
+    if i in snapshot_indices
+        save(joinpath(@__DIR__, "..", "pretwitch_axes_regression_perframe_frame$(lpad(i, 3, '0')).png"), fig)
+    end
+end
+println("wrote $outpath")

--- a/scripts/movie_pretwitch_central_spline.jl
+++ b/scripts/movie_pretwitch_central_spline.jl
@@ -66,6 +66,99 @@ function finite_diff_tangents(curve::Vector{Point3f})
 end
 
 """
+    points_near_ap_plane(pts, ref, ap_position; min_points=2, initial_thresh=40.0, growth=1.5, max_thresh=300.0)
+
+Cells within `initial_thresh` of the cross-sectional plane through
+`ref.origin + ap_position * ref.ap`, perpendicular to `ref.ap` (i.e.
+`|dot(p - ref.origin, ref.ap) - ap_position| < thresh`) -- a LOCAL slice at
+a specific point along the AP axis, not the whole point cloud. `ap_position`
+is a signed scalar offset from `ref.origin` along `ref.ap` (the same units
+as `dot(p - ref.origin, ref.ap)`), so evaluating this at many positions along
+the AP extent gives a genuinely varying (tapering near the ends of an ovoid
+embryo) cross-sectional profile rather than one constant body-wide radius.
+
+`initial_thresh=40` (widened from an initial `15`, which gave a visibly
+jagged radius profile -- adjacent 100-sample slices barely overlapped, so a
+single point entering/leaving a narrow window caused a sharp jump; measured
+directly: max sample-to-sample jump ~16-26 units at thresh=15 vs ~7-16 at
+thresh=40-45 across several frames). Wider slices trade a softer, less sharp
+taper right at the very tips for much smoother variation in between --
+consistent with a real ovoid body rather than sample noise. Callers should
+still pass a per-frame-adjusted `initial_thresh` (see
+[`adaptive_ap_plane_thresh`](@ref)) rather than this flat default, since a
+FIXED width is itself too narrow relative to how sparse early frames are
+(as few as 4 cells total at t=0) -- the same 40 units that works well once
+hundreds of cells exist is comparatively much sparser-sampled early on.
+
+Very early frames have only a handful of cells total (and slices near the
+AP extremes are inherently sparse even later), so the threshold grows (up to
+`max_thresh`) until at least `min_points` fall in the slice -- `min_points`
+defaults to just 2 (the minimum for a non-degenerate extent) rather than
+requiring a fuller sample, since demanding many points near a tapering tip
+would defeat the point of a local measurement.
+"""
+function points_near_ap_plane(pts, ref, ap_position::Real; min_points=2, initial_thresh=40.0, growth=1.5, max_thresh=300.0)
+    thresh = initial_thresh
+    local slice
+    while true
+        slice = filter(p -> abs(dot(p - ref.origin, ref.ap) - ap_position) < thresh, pts)
+        (length(slice) >= min_points || thresh > max_thresh) && break
+        thresh *= growth
+    end
+    return slice
+end
+
+"""
+    adaptive_ap_plane_thresh(n_cells, n_reference; base_thresh=40.0, power=0.2)
+
+Per-FRAME slice threshold for [`points_near_ap_plane`](@ref), scaled up as
+the total number of cells `n_cells` this frame falls short of `n_reference`
+(the final, densest frame's cell count) -- `base_thresh` already tuned to
+look good at `n_reference`. Uses a gentle `n^(-1/5)` power law (the same
+scaling Silverman's rule of thumb uses for kernel-density bandwidth
+selection, chosen for the same reason: density-based smoothing should widen
+slowly with sparsity, not linearly or as `1/sqrt(n)`, which overshoots badly
+at very low `n` -- e.g. only 4 cells at t=0). Confirmed numerically this
+keeps t=180-360 (hundreds of cells) close to the already-tuned 40-45 while
+softening t=0-90 (4-53 cells), where a flat 40 was comparatively too narrow
+(that frame's own cells are much sparser, so the same absolute width
+captures far fewer of them) and gave a jagged profile (max sample-to-sample
+jump ~15.5) that adaptive scaling reduces to ~7.
+"""
+adaptive_ap_plane_thresh(n_cells, n_reference; base_thresh=40.0, power=0.2) =
+    base_thresh * (n_reference / max(n_cells, 1))^power
+
+"""
+    smooth_radii(vecs::Vector{Vec3f}; window=9)
+
+Smooth the MAGNITUDE of each vector in `vecs` with a centered moving average
+over `window` samples (truncated at the ends, so the first/last points
+average over fewer neighbors rather than wrapping or padding with zeros),
+while leaving each vector's DIRECTION untouched -- i.e. this smooths the
+radius profile specifically, not the left-right orientation. Even after
+wider and adaptively-widened slices (see [`points_near_ap_plane`](@ref),
+[`adaptive_ap_plane_thresh`](@ref)), the 100 independently-measured local
+radii can still show sample-to-sample noise; this is an explicit smoothing
+pass on the resulting profile itself, on top of (not instead of) that
+spatial averaging.
+"""
+function smooth_radii(vecs::Vector{Vec3f}; window::Int=9)
+    n = length(vecs)
+    radii = norm.(vecs)
+    # Guard against a degenerate (near-zero-radius) vector at an exact tip --
+    # normalize would otherwise produce NaN, which propagates into the whole
+    # smoothed sequence via the sum below.
+    directions = [r > 1f-6 ? v / r : Vec3f(0, 0, 0) for (v, r) in zip(vecs, radii)]
+    half = window ÷ 2
+    smoothed = map(1:n) do j
+        lo = max(1, j - half)
+        hi = min(n, j + half)
+        sum(@view radii[lo:hi]) / (hi - lo + 1)
+    end
+    return [s * d for (s, d) in zip(smoothed, directions)]
+end
+
+"""
     tube_mesh(interp_curve, right_vecs)
 
 Build a `GeometryBasics.Mesh` tube around `interp_curve`: a circular cross
@@ -135,6 +228,11 @@ const T_END = series.frames[end].time
 # be a plain (non-Observable) array.
 lr_vertex_colors = reduce(vcat, [[c, c] for c in STATION_COLORS[mod1.(1:length(tracks), length(STATION_COLORS))]])
 
+# Reference cell count for adaptive_ap_plane_thresh: the final (densest)
+# frame's total cell count, since that's what the flat thresh=40 default was
+# tuned against.
+const N_CELLS_REFERENCE = length(get_pretwitch_points_at_time(pretwitch_df, series.frames[end].time))
+
 # Precompute all per-frame plot data.
 frame_data = map(1:length(series.frames)) do i
     frame = series.frames[i]
@@ -163,22 +261,37 @@ frame_data = map(1:length(series.frames)) do i
                    [Point3f((1 - w) * m + w * s) for (m, s) in zip(medial_samples, curve)]
 
     # Cross-section radius/orientation: blend, exactly like the curve itself,
-    # between an EARLY vector (half the whole point cloud's left-right extent,
-    # pointing in the fixed reference LR direction -- a constant-radius,
-    # non-twisting cylinder around the straight medial axis) and a LATE
-    # vector (the actual local left-right half-distance/direction at each
-    # terminal seam-cell pair, from right_vector_spline). Blending the full
-    # vector (not radius and direction separately) keeps this identical in
-    # spirit to how interp_curve itself blends full positions.
-    lr_projections = [dot(p - ref.origin, ref.lr) for p in all_pts]
-    lr_lo, lr_hi = extrema(lr_projections)
-    early_right_vec = Vec3f(((lr_hi - lr_lo) / 2) * ref.lr)
-    right_vecs = if isnothing(frame.right_vector_spline)
-        fill(early_right_vec, 100)
-    else
-        [Vec3f((1 - w) * early_right_vec + w * Vec3f(frame.right_vector_spline(x))) for x in range(0, 1, length=100)]
+    # between an EARLY vector and a LATE vector at each of the 100 sample
+    # positions.
+    #
+    # EARLY: half the left-right extent measured at a LOCAL cross-sectional
+    # slice through that sample's own AP position (not one fixed plane, and
+    # NOT the widest point anywhere along the whole body) -- so the resulting
+    # cylinder genuinely tapers near the head/tail, matching the real ovoid
+    # shape of the point cloud, instead of applying one constant radius
+    # everywhere.
+    #
+    # LATE: the actual local left-right half-distance/direction at each
+    # terminal seam-cell pair, from right_vector_spline.
+    #
+    # Blending the full vector (not radius and direction separately) keeps
+    # this identical in spirit to how interp_curve itself blends full
+    # positions.
+    adaptive_thresh = adaptive_ap_plane_thresh(length(all_pts), N_CELLS_REFERENCE)
+    early_right_vecs = map(range(0, 1, length=100)) do x
+        ap_position = lo + (hi - lo) * x
+        slice_pts = points_near_ap_plane(all_pts, ref, ap_position; initial_thresh=adaptive_thresh)
+        lr_projections = [dot(p - ref.origin, ref.lr) for p in slice_pts]
+        lr_lo, lr_hi = extrema(lr_projections)
+        Vec3f(((lr_hi - lr_lo) / 2) * ref.lr)
     end
-    surface = tube_mesh(interp_curve, right_vecs)
+    right_vecs = if isnothing(frame.right_vector_spline)
+        early_right_vecs
+    else
+        [Vec3f((1 - w) * erv + w * Vec3f(frame.right_vector_spline(x)))
+         for (erv, x) in zip(early_right_vecs, range(0, 1, length=100))]
+    end
+    surface = tube_mesh(interp_curve, smooth_radii(right_vecs))
 
     (t=frame.time, all_pts=all_pts, lr_segments=lr_segments, label_pts=label_pts, label_texts=label_texts,
      label_colors=label_colors, knots=frame.knot_positions,

--- a/scripts/movie_pretwitch_central_spline.jl
+++ b/scripts/movie_pretwitch_central_spline.jl
@@ -1,0 +1,187 @@
+using CairoMakie
+using ShroffCelegansModels
+using ShroffCelegansModels: get_pretwitch_df, get_pretwitch_points_at_time, build_pretwitch_central_spline_series,
+    pretwitch_reference_axes, Point3f, dot,
+    left_seam_cells, right_seam_cells
+
+# Verification movie for the pretwitch central spline (see
+# src/demo_averaging/pretwitch_straighten.jl). The fitted central spline is
+# now drawn ONLY through TERMINAL seam cells -- pairs that have reached their
+# exact final differentiated identity, not merely a still-dividing shared
+# ancestor (see PretwitchPairTrack.is_terminal). No pair is terminal before
+# frame 170 (~47% into the pretwitch window), so the curve/knots are simply
+# absent for those early frames; the surrounding ancestor-cell dots/labels
+# and L-R connectors are still shown throughout as context.
+#
+# Each dot is one labeled point per DISTINCT currently-active ancestor cell
+# (not one per seam cell -- many of the 20 L/R seam-cell ancestors share the
+# same actual cell before they've diverged, so plotting all 20 labels would
+# stack duplicates on top of each other). Each label is "<actual cell name>
+# (<seam cells descending from it>)", e.g. "ABar (H2L,V1L,V2L,V4L,V6L,H2R,
+# V1R,V2R,V4R,V6R)". A line is still drawn between each of the 10 canonical
+# L/R pairs' current positions (zero-length if that pair hasn't diverged
+# yet), alongside the existing Approach-1 (WormGuides compass) AP axis arrow
+# for a rough visual reference. The title shows the running terminal-station
+# count and whether THIS frame's nominal knot order also happens to be
+# spatially monotonic along that AP axis -- a diagnostic only, not something
+# that alters the fit.
+
+pretwitch_df = get_pretwitch_df()
+series = build_pretwitch_central_spline_series(pretwitch_df)
+ref = pretwitch_reference_axes(pretwitch_df)
+
+# Rainbow palette, restored from the earlier version of this movie -- one
+# FIXED color per canonical station (H0=1st,...,T=10th), stable across every
+# frame (unlike the old "color by current spline-knot group" scheme, which
+# reassigned colors as stations merged/split from frame to frame).
+const STATION_COLORS = [:red, :orange, :gold, :green, :teal, :blue, :purple, :magenta, :brown, :black]
+
+function sample_spline(frame; n=100)
+    isnothing(frame.central_spline) && return Point3f[]
+    return [Point3f(frame.central_spline(x)) for x in range(0, 1, length=n)]
+end
+
+"""
+    unique_ancestor_labels(tracks, i)
+
+One `(point, label, color)` per DISTINCT currently-active ancestor cell among
+all 20 L/R seam-cell-ancestor positions at pair-track index `i` -- i.e.
+deduplicated by actual cell identity, not by seam-cell name, so stations that
+haven't yet diverged (sharing one physical cell) get exactly one label
+between them. `label` is `"<cell name> (<comma-separated descendant seam
+cells>)"`; `color` is `STATION_COLORS` for whichever canonical station (in
+nominal H0..T order) first contributes that cell.
+"""
+function unique_ancestor_labels(tracks, i)
+    seen = Dict{String,Tuple{Point3f,Vector{String},Any}}()
+    order = String[]
+    for (k, tr) in enumerate(tracks)
+        for (name, pt, seam_label) in ((tr.left_name[i], tr.left[i], left_seam_cells[k]),
+                                        (tr.right_name[i], tr.right[i], right_seam_cells[k]))
+            if haskey(seen, name)
+                push!(seen[name][2], seam_label)
+            else
+                seen[name] = (pt, [seam_label], STATION_COLORS[mod1(k, length(STATION_COLORS))])
+                push!(order, name)
+            end
+        end
+    end
+    pts = [seen[name][1] for name in order]
+    texts = ["$(name) ($(join(seen[name][2], ",")))" for name in order]
+    colors = [seen[name][3] for name in order]
+    return pts, texts, colors
+end
+
+# Raw (unmerged) per-station midpoints -- recompute directly since
+# PretwitchCentralSplineFrame only stores the terminal-only knot positions.
+tracks = ShroffCelegansModels.pretwitch_pair_tracks(pretwitch_df)
+
+# Interpolated curve: medial axis (straight line along the fixed AP
+# direction) at/before the first frame a central spline can be fit, the
+# fitted spline itself by the final frame, and a plain linear blend of the
+# two (sample-by-sample, at matching arc-length-like parameter positions) in
+# between -- i.e. w=0 is pure medial axis, w=1 is pure spline.
+const FIRST_SPLINE_FRAME = findfirst(f -> !isnothing(f.central_spline), series.frames)
+const T_START = series.frames[FIRST_SPLINE_FRAME].time
+const T_END = series.frames[end].time
+
+# Fixed per-station line color, one pair (2 vertices) per canonical station,
+# always in nominal H0..T order -- never changes frame to frame, so this can
+# be a plain (non-Observable) array.
+lr_vertex_colors = reduce(vcat, [[c, c] for c in STATION_COLORS[mod1.(1:length(tracks), length(STATION_COLORS))]])
+
+# Precompute all per-frame plot data.
+frame_data = map(1:length(series.frames)) do i
+    frame = series.frames[i]
+    left_pts = [tr.left[i] for tr in tracks]
+    right_pts = [tr.right[i] for tr in tracks]
+    # Interleaved (left,right,left,right,...) so linesegments! draws one
+    # segment per consecutive pair -- exactly the 10 L/R connecting lines.
+    lr_segments = reduce(vcat, [[l, r] for (l, r) in zip(left_pts, right_pts)])
+    label_pts, label_texts, label_colors = unique_ancestor_labels(tracks, i)
+    all_pts = collect(values(get_pretwitch_points_at_time(pretwitch_df, frame.time)))
+    # Medial axis: the fixed Approach-1 AP axis, extended to span the full
+    # anterior-posterior extent of the ENTIRE point cloud this frame (not a
+    # fixed arbitrary length) -- project every cell onto the axis and take
+    # the extremes, anchored at the axis's own fixed origin so the line
+    # doesn't jitter frame to frame independent of the point cloud's spread.
+    projections = [dot(p - ref.origin, ref.ap) for p in all_pts]
+    lo, hi = extrema(projections)
+    ap_line = [Point3f(ref.origin + lo * ref.ap), Point3f(ref.origin + hi * ref.ap)]
+
+    curve = sample_spline(frame)
+    # Medial axis sampled at the same number of points / parameter positions
+    # as the spline, so the two are pointwise-comparable for interpolation.
+    medial_samples = [Point3f(ref.origin + (lo + (hi - lo) * x) * ref.ap) for x in range(0, 1, length=100)]
+    w = clamp((frame.time - T_START) / (T_END - T_START), 0.0, 1.0)
+    interp_curve = isempty(curve) ? medial_samples :
+                   [Point3f((1 - w) * m + w * s) for (m, s) in zip(medial_samples, curve)]
+
+    (t=frame.time, all_pts=all_pts, lr_segments=lr_segments, label_pts=label_pts, label_texts=label_texts,
+     label_colors=label_colors, knots=frame.knot_positions,
+     curve=curve, n_terminal=length(frame.terminal_stations),
+     ap_line=ap_line, interp_curve=interp_curve, is_ap_monotonic=frame.is_ap_monotonic)
+end
+
+fig = Figure(size=(1300, 800))
+ax = Axis3(fig[1, 1], title="pretwitch central spline", aspect=:data,
+    limits=(50, 350, 20, 220, 40, 240))
+
+all_pts_obs = Observable(frame_data[1].all_pts)
+lr_segments_obs = Observable(frame_data[1].lr_segments)
+label_pts_obs = Observable(frame_data[1].label_pts)
+label_texts_obs = Observable(frame_data[1].label_texts)
+label_colors_obs = Observable(frame_data[1].label_colors)
+knots_obs = Observable(frame_data[1].knots)
+curve_obs = Observable(frame_data[1].curve)
+ap_line_obs = Observable(frame_data[1].ap_line)
+interp_curve_obs = Observable(frame_data[1].interp_curve)
+
+# Background layer (drawn first, so the highlighted seam-cell points/labels
+# render on top of it): every other pretwitch cell at this frame, for context.
+scatter!(ax, all_pts_obs, color=(:gray, 0.35), markersize=5)
+linesegments!(ax, lr_segments_obs, color=lr_vertex_colors, linewidth=2)
+scatter!(ax, label_pts_obs, color=label_colors_obs, marker=:circle, markersize=16, strokecolor=:black, strokewidth=1)
+text!(ax, label_pts_obs; text=label_texts_obs, fontsize=11, align=(:left, :bottom), offset=(6, 6))
+scatter!(ax, knots_obs, color=:black, marker=:star5, markersize=22, strokecolor=:white, strokewidth=1)
+lines!(ax, curve_obs, color=:black, linewidth=3)
+lines!(ax, ap_line_obs, color=:red, linewidth=3, linestyle=:dash)
+lines!(ax, interp_curve_obs, color=:dodgerblue, linewidth=4)
+
+Legend(fig[1, 2],
+    [MarkerElement(color=(:gray, 0.35), marker=:circle, markersize=10),
+     MarkerElement(color=:gray, marker=:circle, markersize=14),
+     LineElement(color=:gray, linewidth=2), MarkerElement(color=:black, marker=:star5, markersize=18),
+     LineElement(color=:black, linewidth=3), LineElement(color=:red, linewidth=3, linestyle=:dash),
+     LineElement(color=:dodgerblue, linewidth=4)],
+    ["other pretwitch cells (context)",
+     "distinct ancestor cell: \"name (descendant seam cells)\" (color = station of first descendant, H0..T)",
+     "L–R pair connector (color = station, H0..T)", "spline knot (terminal seam cell, fixed nominal order)",
+     "fitted central spline (terminal seam cells only)", "medial axis (Approach 1 AP direction, spanning full point cloud)",
+     "interpolated curve (medial axis at t=$(T_START) -> spline at t=$(T_END), linear blend)"],
+    "Legend")
+
+title_str(d) = "t=$(d.t)  terminal stations: $(d.n_terminal)/10  spatially AP-monotonic: $(d.is_ap_monotonic)"
+title_obs = Observable(title_str(frame_data[1]))
+Label(fig[0, 1:2], title_obs, fontsize=20, tellwidth=false)
+
+snapshot_indices = Set([1, 31, 91, 151, 181, 271, 361])
+
+outpath = joinpath(@__DIR__, "..", "pretwitch_central_spline.mp4")
+record(fig, outpath, eachindex(frame_data); framerate=24) do i
+    d = frame_data[i]
+    all_pts_obs[] = d.all_pts
+    lr_segments_obs[] = d.lr_segments
+    label_pts_obs[] = d.label_pts
+    label_texts_obs[] = d.label_texts
+    label_colors_obs[] = d.label_colors
+    knots_obs[] = d.knots
+    curve_obs[] = d.curve
+    ap_line_obs[] = d.ap_line
+    interp_curve_obs[] = d.interp_curve
+    title_obs[] = title_str(d)
+    if i in snapshot_indices
+        save(joinpath(@__DIR__, "..", "pretwitch_central_spline_frame$(lpad(i, 3, '0')).png"), fig)
+    end
+end
+println("wrote $outpath")

--- a/scripts/movie_pretwitch_central_spline.jl
+++ b/scripts/movie_pretwitch_central_spline.jl
@@ -1,7 +1,7 @@
 using CairoMakie
 using ShroffCelegansModels
 using ShroffCelegansModels: get_pretwitch_df, get_pretwitch_points_at_time, build_pretwitch_central_spline_series,
-    pretwitch_reference_axes, Point3f, dot,
+    pretwitch_reference_axes, Point3f, Vec3f, dot, cross, normalize, norm,
     left_seam_cells, right_seam_cells
 
 # Verification movie for the pretwitch central spline (see
@@ -25,6 +25,12 @@ using ShroffCelegansModels: get_pretwitch_df, get_pretwitch_points_at_time, buil
 # count and whether THIS frame's nominal knot order also happens to be
 # spatially monotonic along that AP axis -- a diagnostic only, not something
 # that alters the fit.
+#
+# Renders two outputs via render_pretwitch_central_spline_movie (single
+# function, `show_surface` keyword toggles the body-surface tube mesh; the
+# expensive per-frame precomputation, including tube meshes, is shared
+# between both calls): pretwitch_central_spline.mp4 (curve-only, no surface)
+# and pretwitch_central_spline_with_surface.mp4 (includes the body surface).
 
 pretwitch_df = get_pretwitch_df()
 series = build_pretwitch_central_spline_series(pretwitch_df)
@@ -39,6 +45,45 @@ const STATION_COLORS = [:red, :orange, :gold, :green, :teal, :blue, :purple, :ma
 function sample_spline(frame; n=100)
     isnothing(frame.central_spline) && return Point3f[]
     return [Point3f(frame.central_spline(x)) for x in range(0, 1, length=n)]
+end
+
+"""
+    finite_diff_tangents(curve)
+
+Unit tangent at each point of `curve` via central differences (forward/
+backward at the endpoints) -- a simple numerical stand-in for an analytic
+derivative, adequate for orienting cross-section circles on the already-
+blended `interp_curve` (which has no single analytic spline of its own).
+"""
+function finite_diff_tangents(curve::Vector{Point3f})
+    n = length(curve)
+    map(1:n) do j
+        d = j == 1 ? curve[2] - curve[1] :
+            j == n ? curve[n] - curve[n-1] :
+            curve[j+1] - curve[j-1]
+        normalize(Vec3f(d))
+    end
+end
+
+"""
+    tube_mesh(interp_curve, right_vecs)
+
+Build a `GeometryBasics.Mesh` tube around `interp_curve`: a circular cross
+section at each sample point, oriented by the local tangent (finite
+differences, see [`finite_diff_tangents`](@ref)) and the local `right_vecs[j]`
+(already scaled to the desired radius -- see how `right_vec` is blended in
+the main per-frame loop below), exactly mirroring `build_celegans_model`'s
+posttwitch convention: `normal = normalize(cross(tangent, right)) * radius`,
+then `get_circle_points(right, normal, center)` for 32 points/ring, stitched
+into quads by the same `get_model_contour_mesh` posttwitch uses.
+"""
+function tube_mesh(interp_curve::Vector{Point3f}, right_vecs::Vector{Vec3f})
+    tangents = finite_diff_tangents(interp_curve)
+    sections = map(interp_curve, tangents, right_vecs) do center, tangent, rv
+        normal = normalize(cross(tangent, rv)) * norm(rv)
+        Point3f.(ShroffCelegansModels.get_circle_points(rv, normal, center))
+    end
+    return ShroffCelegansModels.get_model_contour_mesh(sections)
 end
 
 """
@@ -117,71 +162,118 @@ frame_data = map(1:length(series.frames)) do i
     interp_curve = isempty(curve) ? medial_samples :
                    [Point3f((1 - w) * m + w * s) for (m, s) in zip(medial_samples, curve)]
 
+    # Cross-section radius/orientation: blend, exactly like the curve itself,
+    # between an EARLY vector (half the whole point cloud's left-right extent,
+    # pointing in the fixed reference LR direction -- a constant-radius,
+    # non-twisting cylinder around the straight medial axis) and a LATE
+    # vector (the actual local left-right half-distance/direction at each
+    # terminal seam-cell pair, from right_vector_spline). Blending the full
+    # vector (not radius and direction separately) keeps this identical in
+    # spirit to how interp_curve itself blends full positions.
+    lr_projections = [dot(p - ref.origin, ref.lr) for p in all_pts]
+    lr_lo, lr_hi = extrema(lr_projections)
+    early_right_vec = Vec3f(((lr_hi - lr_lo) / 2) * ref.lr)
+    right_vecs = if isnothing(frame.right_vector_spline)
+        fill(early_right_vec, 100)
+    else
+        [Vec3f((1 - w) * early_right_vec + w * Vec3f(frame.right_vector_spline(x))) for x in range(0, 1, length=100)]
+    end
+    surface = tube_mesh(interp_curve, right_vecs)
+
     (t=frame.time, all_pts=all_pts, lr_segments=lr_segments, label_pts=label_pts, label_texts=label_texts,
      label_colors=label_colors, knots=frame.knot_positions,
      curve=curve, n_terminal=length(frame.terminal_stations),
-     ap_line=ap_line, interp_curve=interp_curve, is_ap_monotonic=frame.is_ap_monotonic)
+     ap_line=ap_line, interp_curve=interp_curve, surface=surface, is_ap_monotonic=frame.is_ap_monotonic)
 end
 
-fig = Figure(size=(1300, 800))
-ax = Axis3(fig[1, 1], title="pretwitch central spline", aspect=:data,
-    limits=(50, 350, 20, 220, 40, 240))
-
-all_pts_obs = Observable(frame_data[1].all_pts)
-lr_segments_obs = Observable(frame_data[1].lr_segments)
-label_pts_obs = Observable(frame_data[1].label_pts)
-label_texts_obs = Observable(frame_data[1].label_texts)
-label_colors_obs = Observable(frame_data[1].label_colors)
-knots_obs = Observable(frame_data[1].knots)
-curve_obs = Observable(frame_data[1].curve)
-ap_line_obs = Observable(frame_data[1].ap_line)
-interp_curve_obs = Observable(frame_data[1].interp_curve)
-
-# Background layer (drawn first, so the highlighted seam-cell points/labels
-# render on top of it): every other pretwitch cell at this frame, for context.
-scatter!(ax, all_pts_obs, color=(:gray, 0.35), markersize=5)
-linesegments!(ax, lr_segments_obs, color=lr_vertex_colors, linewidth=2)
-scatter!(ax, label_pts_obs, color=label_colors_obs, marker=:circle, markersize=16, strokecolor=:black, strokewidth=1)
-text!(ax, label_pts_obs; text=label_texts_obs, fontsize=11, align=(:left, :bottom), offset=(6, 6))
-scatter!(ax, knots_obs, color=:black, marker=:star5, markersize=22, strokecolor=:white, strokewidth=1)
-lines!(ax, curve_obs, color=:black, linewidth=3)
-lines!(ax, ap_line_obs, color=:red, linewidth=3, linestyle=:dash)
-lines!(ax, interp_curve_obs, color=:dodgerblue, linewidth=4)
-
-Legend(fig[1, 2],
-    [MarkerElement(color=(:gray, 0.35), marker=:circle, markersize=10),
-     MarkerElement(color=:gray, marker=:circle, markersize=14),
-     LineElement(color=:gray, linewidth=2), MarkerElement(color=:black, marker=:star5, markersize=18),
-     LineElement(color=:black, linewidth=3), LineElement(color=:red, linewidth=3, linestyle=:dash),
-     LineElement(color=:dodgerblue, linewidth=4)],
-    ["other pretwitch cells (context)",
-     "distinct ancestor cell: \"name (descendant seam cells)\" (color = station of first descendant, H0..T)",
-     "L–R pair connector (color = station, H0..T)", "spline knot (terminal seam cell, fixed nominal order)",
-     "fitted central spline (terminal seam cells only)", "medial axis (Approach 1 AP direction, spanning full point cloud)",
-     "interpolated curve (medial axis at t=$(T_START) -> spline at t=$(T_END), linear blend)"],
-    "Legend")
-
 title_str(d) = "t=$(d.t)  terminal stations: $(d.n_terminal)/10  spatially AP-monotonic: $(d.is_ap_monotonic)"
-title_obs = Observable(title_str(frame_data[1]))
-Label(fig[0, 1:2], title_obs, fontsize=20, tellwidth=false)
+
+"""
+    render_pretwitch_central_spline_movie(frame_data; show_surface=true, outpath, snapshot_indices=Set{Int}())
+
+Render the pretwitch central-spline verification movie from precomputed
+`frame_data`. `show_surface` toggles the body-surface tube mesh (see
+[`tube_mesh`](@ref)) on or off -- everything else (background cells, L/R
+connectors, ancestor labels, fitted spline, medial axis, interpolated curve)
+is always shown. Set `show_surface=false` for a lighter-weight, curve-only
+view when the surface itself isn't the point.
+"""
+function render_pretwitch_central_spline_movie(frame_data; show_surface::Bool=true, outpath, snapshot_indices=Set{Int}())
+    fig = Figure(size=(1300, 800))
+    ax = Axis3(fig[1, 1], title="pretwitch central spline", aspect=:data,
+        limits=(50, 350, 20, 220, 40, 240))
+
+    all_pts_obs = Observable(frame_data[1].all_pts)
+    lr_segments_obs = Observable(frame_data[1].lr_segments)
+    label_pts_obs = Observable(frame_data[1].label_pts)
+    label_texts_obs = Observable(frame_data[1].label_texts)
+    label_colors_obs = Observable(frame_data[1].label_colors)
+    knots_obs = Observable(frame_data[1].knots)
+    curve_obs = Observable(frame_data[1].curve)
+    ap_line_obs = Observable(frame_data[1].ap_line)
+    interp_curve_obs = Observable(frame_data[1].interp_curve)
+
+    # Background layer (drawn first, so the highlighted seam-cell points/labels
+    # render on top of it): every other pretwitch cell at this frame, for context.
+    scatter!(ax, all_pts_obs, color=(:gray, 0.35), markersize=5)
+    surface_obs = nothing
+    if show_surface
+        surface_obs = Observable(frame_data[1].surface)
+        mesh!(ax, surface_obs, color=(:skyblue, 0.25), transparency=true)
+    end
+    linesegments!(ax, lr_segments_obs, color=lr_vertex_colors, linewidth=2)
+    scatter!(ax, label_pts_obs, color=label_colors_obs, marker=:circle, markersize=16, strokecolor=:black, strokewidth=1)
+    text!(ax, label_pts_obs; text=label_texts_obs, fontsize=11, align=(:left, :bottom), offset=(6, 6))
+    scatter!(ax, knots_obs, color=:black, marker=:star5, markersize=22, strokecolor=:white, strokewidth=1)
+    lines!(ax, curve_obs, color=:black, linewidth=3)
+    lines!(ax, ap_line_obs, color=:red, linewidth=3, linestyle=:dash)
+    lines!(ax, interp_curve_obs, color=:dodgerblue, linewidth=4)
+
+    legend_elements = Any[MarkerElement(color=(:gray, 0.35), marker=:circle, markersize=10)]
+    legend_labels = String["other pretwitch cells (context)"]
+    if show_surface
+        push!(legend_elements, PolyElement(color=(:skyblue, 0.25)))
+        push!(legend_labels, "body surface (circular cross-sections around interpolated curve)")
+    end
+    append!(legend_elements, [
+        MarkerElement(color=:gray, marker=:circle, markersize=14),
+        LineElement(color=:gray, linewidth=2), MarkerElement(color=:black, marker=:star5, markersize=18),
+        LineElement(color=:black, linewidth=3), LineElement(color=:red, linewidth=3, linestyle=:dash),
+        LineElement(color=:dodgerblue, linewidth=4)])
+    append!(legend_labels, [
+        "distinct ancestor cell: \"name (descendant seam cells)\" (color = station of first descendant, H0..T)",
+        "L–R pair connector (color = station, H0..T)", "spline knot (terminal seam cell, fixed nominal order)",
+        "fitted central spline (terminal seam cells only)", "medial axis (Approach 1 AP direction, spanning full point cloud)",
+        "interpolated curve (medial axis at t=$(T_START) -> spline at t=$(T_END), linear blend)"])
+    Legend(fig[1, 2], legend_elements, legend_labels, "Legend")
+
+    title_obs = Observable(title_str(frame_data[1]))
+    Label(fig[0, 1:2], title_obs, fontsize=20, tellwidth=false)
+
+    snapshot_prefix = splitext(outpath)[1]
+    record(fig, outpath, eachindex(frame_data); framerate=24) do i
+        d = frame_data[i]
+        all_pts_obs[] = d.all_pts
+        lr_segments_obs[] = d.lr_segments
+        label_pts_obs[] = d.label_pts
+        label_texts_obs[] = d.label_texts
+        label_colors_obs[] = d.label_colors
+        knots_obs[] = d.knots
+        curve_obs[] = d.curve
+        ap_line_obs[] = d.ap_line
+        interp_curve_obs[] = d.interp_curve
+        show_surface && (surface_obs[] = d.surface)
+        title_obs[] = title_str(d)
+        if i in snapshot_indices
+            save("$(snapshot_prefix)_frame$(lpad(i, 3, '0')).png", fig)
+        end
+    end
+    println("wrote $outpath")
+end
 
 snapshot_indices = Set([1, 31, 91, 151, 181, 271, 361])
 
-outpath = joinpath(@__DIR__, "..", "pretwitch_central_spline.mp4")
-record(fig, outpath, eachindex(frame_data); framerate=24) do i
-    d = frame_data[i]
-    all_pts_obs[] = d.all_pts
-    lr_segments_obs[] = d.lr_segments
-    label_pts_obs[] = d.label_pts
-    label_texts_obs[] = d.label_texts
-    label_colors_obs[] = d.label_colors
-    knots_obs[] = d.knots
-    curve_obs[] = d.curve
-    ap_line_obs[] = d.ap_line
-    interp_curve_obs[] = d.interp_curve
-    title_obs[] = title_str(d)
-    if i in snapshot_indices
-        save(joinpath(@__DIR__, "..", "pretwitch_central_spline_frame$(lpad(i, 3, '0')).png"), fig)
-    end
-end
-println("wrote $outpath")
+render_pretwitch_central_spline_movie(frame_data; show_surface=false,
+    outpath=joinpath(@__DIR__, "..", "pretwitch_central_spline.mp4"))
+render_pretwitch_central_spline_movie(frame_data; show_surface=true,
+    outpath=joinpath(@__DIR__, "..", "pretwitch_central_spline_with_surface.mp4"), snapshot_indices)

--- a/scripts/regress_pretwitch_axis_weights.jl
+++ b/scripts/regress_pretwitch_axis_weights.jl
@@ -1,0 +1,153 @@
+using ShroffCelegansModels
+using ShroffCelegansModels: get_pretwitch_df, get_pretwitch_points_at_time,
+    pretwitch_reference_axes, pretwitch_axes_at_time, pretwitch_cells_by_name,
+    Point3f, normalize, dot
+using LinearAlgebra: I as LinearAlgebraI
+using Statistics: mean
+
+# v2: the first attempt (regress_pretwitch_axis_weights.jl) used each LEAF
+# lineage's full ancestor-spliced track as a feature. That's badly collinear:
+# sibling leaves that only diverged in the last few frames share an IDENTICAL
+# trajectory for most of development, so ridge regression just split weight
+# arbitrarily among them (near-perfect train AND test fit, even/odd-frame
+# split leaks via adjacency, no real signal). v2 instead uses each cell's own
+# RAW, un-spliced existence window as a separate feature (1332 candidates,
+# naturally non-redundant since siblings occupy different positions once
+# divided), and validates with a genuine block-level train/test split
+# (train on epochs 1,3,5; test on held-out epochs 2,4,6) instead of
+# alternating frames.
+
+pretwitch_df = get_pretwitch_df()
+ref = pretwitch_reference_axes(pretwitch_df)
+grouped = pretwitch_cells_by_name(pretwitch_df)
+
+times = sort(unique(pretwitch_df.time))
+
+println("Precomputing per-frame centroid + Approach-1 axes for $(length(times)) timepoints...")
+centroid_of = Dict{Int,Point3f}()
+axes_of = Dict{Int,Any}()
+for t in times
+    pts = collect(values(get_pretwitch_points_at_time(pretwitch_df, t)))
+    centroid_of[t] = Point3f(sum(pts) / length(pts))
+    axes_of[t] = pretwitch_axes_at_time(ref, t)
+end
+
+const MIN_DIST = 10f0
+norm3(v) = sqrt(sum(abs2, v))
+
+println("Building raw (un-spliced) direction tracks for $(length(grouped)) distinct cell names...")
+dir_tracks = Dict{String,Dict{Int,Vector{Float64}}}()
+for (name, rows) in grouped
+    d = Dict{Int,Vector{Float64}}()
+    for (t, p) in rows
+        v = p - centroid_of[t]
+        norm3(v) < MIN_DIST && continue
+        d[t] = Float64.(normalize(v))
+    end
+    length(d) >= 10 && (dir_tracks[name] = d)  # need enough frames to be a useful feature
+end
+println("$(length(dir_tracks)) names retained (>=10 usable frames each).")
+
+const NEPOCHS = 6
+epoch_bounds = round.(Int, range(minimum(times), maximum(times), length=NEPOCHS + 1))
+epochs = [epoch_bounds[i]:epoch_bounds[i+1] for i in 1:NEPOCHS]
+train_times = reduce(vcat, [collect(epochs[i]) for i in 1:2:NEPOCHS])
+test_times = reduce(vcat, [collect(epochs[i]) for i in 2:2:NEPOCHS])
+train_times = unique(train_times); test_times = unique(test_times)
+println("train frames: $(length(train_times)) (epochs 1,3,5)   test frames: $(length(test_times)) (epochs 2,4,6)")
+
+function fit_axis(axis_field::Symbol, lambda::Float64; fit_times=train_times)
+    names = collect(keys(dir_tracks))
+    n = length(names)
+
+    Xtr = zeros(3 * length(fit_times), n)
+    ytr = zeros(3 * length(fit_times))
+    for (ti, t) in enumerate(fit_times)
+        target = getfield(axes_of[t], axis_field)
+        for k in 1:3
+            ytr[3*(ti-1)+k] = target[k]
+        end
+        for (ci, name) in enumerate(names)
+            d = dir_tracks[name]
+            haskey(d, t) || continue
+            for k in 1:3
+                Xtr[3*(ti-1)+k, ci] = d[t][k]
+            end
+        end
+    end
+
+    w = (Xtr'Xtr + lambda * LinearAlgebraI(n)) \ (Xtr'ytr)
+
+    function fit_quality(ts)
+        sims = Float64[]
+        for t in ts
+            target = getfield(axes_of[t], axis_field)
+            pred = zeros(3)
+            for (ci, name) in enumerate(names)
+                d = dir_tracks[name]
+                haskey(d, t) || continue
+                pred .+= w[ci] .* d[t]
+            end
+            nrm = norm3(pred)
+            nrm < 1e-6 && continue
+            push!(sims, dot(pred ./ nrm, Vector(target)))
+        end
+        isempty(sims) ? NaN : mean(sims)
+    end
+
+    return names, w, fit_quality(train_times), fit_quality(test_times)
+end
+
+const LAMBDAS = [10.0, 30.0, 100.0, 300.0, 1000.0, 3000.0, 10000.0]
+
+# Final production weights per axis (refit on ALL 361 frames, at the lambda
+# that generalized best in the train/test validation above) -- the
+# validation split's job is done once we've picked lambda; the actual
+# weights used downstream (CSV export, movie) should use every frame.
+production_weights = Dict{Symbol,Any}()
+
+for axis_field in (:dv, :lr)
+    println()
+    println("="^70)
+    println("Axis target: Approach 1's $(axis_field)(t)  (single global fit, all 361 frames)")
+    println("="^70)
+    best = nothing
+    for lambda in LAMBDAS
+        names, w, train_fit, test_fit = fit_axis(axis_field, lambda)
+        println("  lambda=$lambda: train_fit=$(round(train_fit,digits=3)) test_fit=$(round(test_fit,digits=3))")
+        if best === nothing || test_fit > best.test_fit
+            best = (; lambda, names, w, train_fit, test_fit)
+        end
+    end
+    println("Best: lambda=$(best.lambda) train_fit=$(round(best.train_fit,digits=3)) test_fit=$(round(best.test_fit,digits=3))")
+    order = sortperm(abs.(best.w), rev=true)
+    println("Top 15 weighted cells:")
+    for i in order[1:15]
+        println("    $(best.names[i]): w=$(round(best.w[i],digits=4))")
+    end
+
+    names_full, w_full, train_fit_full, _ = fit_axis(axis_field, best.lambda; fit_times=times)
+    println("Refit on all $(length(times)) frames at lambda=$(best.lambda): fit=$(round(train_fit_full,digits=3))")
+    production_weights[axis_field] = (names=names_full, w=w_full)
+end
+
+# --- CSV export ---
+# Both axes were fit over the same candidate set (`dir_tracks`, unchanged
+# between calls), so `names` is in the same order for both -- safe to zip
+# into one table.
+dv_names, dv_w = production_weights[:dv].names, production_weights[:dv].w
+lr_names, lr_w = production_weights[:lr].names, production_weights[:lr].w
+@assert dv_names == lr_names "candidate name order differs between dv/lr fits"
+
+csv_path = joinpath(@__DIR__, "..", "pretwitch_axis_regression_weights.csv")
+open(csv_path, "w") do io
+    println(io, "name,n_frames,dv_weight,lr_weight")
+    order = sortperm(abs.(dv_w) .+ abs.(lr_w), rev=true)
+    for i in order
+        name = dv_names[i]
+        n_frames = length(dir_tracks[name])
+        println(io, "$name,$n_frames,$(dv_w[i]),$(lr_w[i])")
+    end
+end
+println()
+println("wrote $csv_path")

--- a/scripts/scan_pretwitch_axis_candidates.jl
+++ b/scripts/scan_pretwitch_axis_candidates.jl
@@ -1,0 +1,100 @@
+using ShroffCelegansModels
+using ShroffCelegansModels: get_pretwitch_df, get_pretwitch_points_at_time,
+    pretwitch_reference_axes, pretwitch_axes_at_time, pretwitch_cells_by_name,
+    pretwitch_lineage_track, Point3f, normalize, dot
+using Statistics: mean, std
+
+# Approach 3 (pretwitch_orientation.txt item 3): treat Approach 1's WormGuides
+# compass interpolation as a working hypothesis ("expert knowledge") and look
+# for individual pretwitch cell lineages whose position relative to the body
+# centroid stays consistently aligned with Approach 1's rotating DV/LR axes
+# across the whole pretwitch window. Also specifically "work back" (via full
+# ancestor-lineage reconstruction) from cells already identified as DV/LR
+# markers in the posttwitch lattice_orientation.jl / check_lattice_orientation.jl
+# QC (Cpaaaa, ABplaappap, Caaaaa for DV; ABarpaappp for LR) to see whether
+# their pretwitch ancestry also tracks Approach 1's axes.
+
+pretwitch_df = get_pretwitch_df()
+ref = pretwitch_reference_axes(pretwitch_df)
+grouped = pretwitch_cells_by_name(pretwitch_df)
+
+times = sort(unique(pretwitch_df.time))
+
+println("Precomputing per-frame centroid + Approach-1 axes for $(length(times)) timepoints...")
+centroid_of = Dict{Int,Point3f}()
+axes_of = Dict{Int,Any}()
+for t in times
+    pts = collect(values(get_pretwitch_points_at_time(pretwitch_df, t)))
+    centroid_of[t] = Point3f(sum(pts) / length(pts))
+    axes_of[t] = pretwitch_axes_at_time(ref, t)
+end
+
+const MIN_DIST = 10f0  # ignore frames where the cell is too close to centroid for direction to be meaningful
+
+"""
+    axis_alignment(name)
+
+Reconstruct `name`'s full ancestor-lineage track and return
+`(n_frames, mean_dv, std_dv, mean_lr, std_lr)` scoring how consistently its
+direction from the per-frame body centroid aligns with Approach 1's `dv(t)`
+and `lr(t)` axes.
+"""
+function axis_alignment(name)
+    ts, pts = pretwitch_lineage_track(name, grouped)
+    dv_scores = Float64[]
+    lr_scores = Float64[]
+    for (t, p) in zip(ts, pts)
+        v = p - centroid_of[t]
+        norm(v) < MIN_DIST && continue
+        vhat = normalize(v)
+        a = axes_of[t]
+        push!(dv_scores, dot(vhat, a.dv))
+        push!(lr_scores, dot(vhat, a.lr))
+    end
+    isempty(dv_scores) && return (0, NaN, NaN, NaN, NaN)
+    return (length(dv_scores), mean(dv_scores), std(dv_scores), mean(lr_scores), std(lr_scores))
+end
+
+norm(v) = sqrt(sum(abs2, v))
+
+println()
+println("=== Cross-check: known posttwitch DV/LR marker cells (lattice_orientation.jl), tracked back through pretwitch ===")
+known = [
+    ("Cpaaaa", :dv, "hyp7_Cpaaaa (the original DV-swap check cell)"),
+    ("ABplaappap", :dv, "hyp6_ABplaappap (DV survey candidate)"),
+    ("Caaaaa", :dv, "hyp7_Caaaaa (DV survey candidate)"),
+    ("ABarpaappp", :lr, "hyp7_ABarpaappp (LR survey candidate)"),
+]
+for (name, axis, label) in known
+    n, mdv, sdv, mlr, slr = axis_alignment(name)
+    println("$label:")
+    println("  n_frames=$n  mean_dv=$(round(mdv,digits=3)) std_dv=$(round(sdv,digits=3))  mean_lr=$(round(mlr,digits=3)) std_lr=$(round(slr,digits=3))")
+end
+
+println()
+println("=== Broad scan: every leaf lineage present at the final pretwitch timepoint ===")
+last_t = maximum(times)
+leaves = collect(keys(get_pretwitch_points_at_time(pretwitch_df, last_t)))
+println("Scanning $(length(leaves)) leaf lineages...")
+
+results = map(leaves) do name
+    n, mdv, sdv, mlr, slr = axis_alignment(name)
+    (name=name, n=n, mean_dv=mdv, std_dv=sdv, mean_lr=mlr, std_lr=slr)
+end
+results = filter(r -> r.n >= 100, results)  # require a long, statistically meaningful track
+
+println("($(length(results)) of $(length(leaves)) leaves have >=100 aligned frames)")
+
+println()
+println("--- Top 15 DV-axis candidates (by |mean_dv|, low std_dv preferred) ---")
+dv_ranked = sort(results, by=r -> -abs(r.mean_dv) + r.std_dv)
+for r in first(dv_ranked, 15)
+    println("$(r.name): n=$(r.n) mean_dv=$(round(r.mean_dv,digits=3)) std_dv=$(round(r.std_dv,digits=3))")
+end
+
+println()
+println("--- Top 15 LR-axis candidates (by |mean_lr|, low std_lr preferred) ---")
+lr_ranked = sort(results, by=r -> -abs(r.mean_lr) + r.std_lr)
+for r in first(lr_ranked, 15)
+    println("$(r.name): n=$(r.n) mean_lr=$(round(r.mean_lr,digits=3)) std_lr=$(round(r.std_lr,digits=3))")
+end

--- a/src/ShroffCelegansModels.jl
+++ b/src/ShroffCelegansModels.jl
@@ -86,6 +86,7 @@ module ShroffCelegansModels
     # build the combined pretwitch+posttwitch dataframe for the pipeline.
     include("seam_cell_to_lineage_map.jl")
     include("demo_averaging/pretwitch_orientation.jl")
+    include("demo_averaging/pretwitch_straighten.jl")
     include("demo_averaging/explicit_export.jl")
     include("recompute_pipeline.jl")
     include("makie.jl")

--- a/src/ShroffCelegansModels.jl
+++ b/src/ShroffCelegansModels.jl
@@ -85,6 +85,7 @@ module ShroffCelegansModels
     # explicit_export.jl uses those + get_seam_cells_explicit_df to
     # build the combined pretwitch+posttwitch dataframe for the pipeline.
     include("seam_cell_to_lineage_map.jl")
+    include("demo_averaging/pretwitch_orientation.jl")
     include("demo_averaging/explicit_export.jl")
     include("recompute_pipeline.jl")
     include("makie.jl")

--- a/src/demo_averaging/pretwitch_orientation.jl
+++ b/src/demo_averaging/pretwitch_orientation.jl
@@ -92,7 +92,9 @@ for `"Cpaaaa"`, the chain is `"C"`, `"Cp"`, `"Cpa"`, `"Cpaa"`, `"Cpaaa"`,
 [`pretwitch_cells_by_name`](@ref). Ancestor prefixes not present as their own
 distinct name in `grouped` (division doesn't always add exactly one
 character in a way that leaves every prefix separately observed) are simply
-skipped. Returns `(times, points)` sorted by time.
+skipped. Returns `(times, points, ancestor_names)` sorted by time, where
+`ancestor_names[i]` is the ancestor prefix that produced `points[i]` (which
+ancestor was "active" at `times[i]`).
 
 This is what "working back from" a cell like Cpaaaa (identified in the
 posttwitch lattice orientation QC, see `lattice_orientation.jl`) to the
@@ -100,13 +102,17 @@ pretwitch stage means concretely: its full ancestry, not just the single
 frame where `target_name` itself first appears.
 """
 function pretwitch_lineage_track(target_name::AbstractString, grouped::AbstractDict{String})
-    track = Tuple{Int,Point3f}[]
+    track = Tuple{Int,Point3f,String}[]
     for k in 1:length(target_name)
         prefix = target_name[1:k]
-        haskey(grouped, prefix) && append!(track, grouped[prefix])
+        if haskey(grouped, prefix)
+            for (t, p) in grouped[prefix]
+                push!(track, (t, p, prefix))
+            end
+        end
     end
     sort!(track, by=first)
-    return first.(track), last.(track)
+    return first.(track), getindex.(track, 2), getindex.(track, 3)
 end
 
 """

--- a/src/demo_averaging/pretwitch_orientation.jl
+++ b/src/demo_averaging/pretwitch_orientation.jl
@@ -1,0 +1,245 @@
+# Establish anterior-posterior (AP), dorsal-ventral (DV), and left-right (LR)
+# axes for the pretwitch embryo (see pretwitch_orientation.txt for the design
+# notes this implements).
+#
+# Approach 1 (WormGuides compass interpolation): the AP axis is fixed, derived
+# once from the four-cell stage (ABa/ABp/P2/EMS). The DV/LR basis is assumed
+# to rotate rigidly about that fixed AP axis over the course of development,
+# with the rotation angle given by WormGuides' Key_Frames_Rotate /
+# Key_Values_Rotate compass table. The compass's 90 degree value at frame 1
+# is defined to reproduce the directly observed four-cell-stage DV direction,
+# so the interpolated angle is a rotation *relative to that calibration*, not
+# an absolute lab-frame heading.
+#
+# This is explicitly a first, unvalidated attempt (see pretwitch_orientation.txt
+# item 1) -- the left/right sign of the LR axis is NOT anatomically resolved
+# here (that requires either lineage-descendant markers, approach 2, or
+# cross-checking against posttwitch orientation as in lattice_orientation.jl,
+# approach 3).
+
+const _WORMGUIDES_COMPASS_KEY_FRAMES = [1, 16, 321, 359]
+const _WORMGUIDES_COMPASS_KEY_VALUES_DEG = [90.0, 30.0, 30.0, 90.0]
+
+"""
+    wormguides_compass_angle(frame; key_frames=_WORMGUIDES_COMPASS_KEY_FRAMES,
+                                     key_values_deg=_WORMGUIDES_COMPASS_KEY_VALUES_DEG)
+
+Piecewise-linear interpolation of the WormGuides compass rotation angle (in
+radians) at a given `frame`, per the `Key_Frames_Rotate` / `Key_Values_Rotate`
+table in pretwitch_orientation.txt. Clamped to the first/last key value outside
+the key frame range.
+"""
+function wormguides_compass_angle(
+    frame::Real;
+    key_frames::AbstractVector{<:Real}=_WORMGUIDES_COMPASS_KEY_FRAMES,
+    key_values_deg::AbstractVector{<:Real}=_WORMGUIDES_COMPASS_KEY_VALUES_DEG,
+)
+    if frame <= key_frames[1]
+        return deg2rad(key_values_deg[1])
+    elseif frame >= key_frames[end]
+        return deg2rad(key_values_deg[end])
+    end
+    i = searchsortedlast(key_frames, frame)
+    f0, f1 = key_frames[i], key_frames[i+1]
+    v0, v1 = key_values_deg[i], key_values_deg[i+1]
+    L = (frame - f0) / (f1 - f0)
+    return deg2rad(v0 + L * (v1 - v0))
+end
+
+"""
+    pretwitch_time_to_wormguides_frame(time)
+
+Pretwitch `time` runs 0-360 (361 timepoints, matching `get_pretwitch_df`'s
+`time` column); WormGuides frames run 1-360. Frame = time + 1.
+"""
+pretwitch_time_to_wormguides_frame(time::Real) = time + 1
+
+"""
+    pretwitch_four_cell_points(pretwitch_df; time=0)
+
+Return the (ABa, ABp, P2, EMS) points at the four-cell stage (`time`, default
+0) as a NamedTuple of `Point3f`s.
+"""
+function pretwitch_four_cell_points(pretwitch_df; time::Int=0)
+    pts = get_pretwitch_points_at_time(pretwitch_df, time)
+    return (ABa=pts["ABa"], ABp=pts["ABp"], P2=pts["P2"], EMS=pts["EMS"])
+end
+
+"""
+    pretwitch_cells_by_name(pretwitch_df)
+
+Group `pretwitch_df` by cell/lineage name, returning
+`Dict{String, Vector{Tuple{Int,Point3f}}}` of that cell's own
+`(time, position)` pairs (its existence window, before it either divides into
+two differently-named daughters or the pretwitch dataset ends).
+"""
+function pretwitch_cells_by_name(pretwitch_df)
+    grouped = Dict{String, Vector{Tuple{Int,Point3f}}}()
+    for row in eachrow(pretwitch_df)
+        push!(get!(() -> Tuple{Int,Point3f}[], grouped, row.cell),
+              (row.time, Point3f(row.x, row.y, row.z)))
+    end
+    return grouped
+end
+
+"""
+    pretwitch_lineage_track(target_name, grouped)
+
+Reconstruct a single continuous position trajectory for `target_name` by
+splicing together the existence windows of its full ancestor chain -- e.g.
+for `"Cpaaaa"`, the chain is `"C"`, `"Cp"`, `"Cpa"`, `"Cpaa"`, `"Cpaaa"`,
+`"Cpaaaa"` (each a division away from the next). `grouped` is the output of
+[`pretwitch_cells_by_name`](@ref). Ancestor prefixes not present as their own
+distinct name in `grouped` (division doesn't always add exactly one
+character in a way that leaves every prefix separately observed) are simply
+skipped. Returns `(times, points)` sorted by time.
+
+This is what "working back from" a cell like Cpaaaa (identified in the
+posttwitch lattice orientation QC, see `lattice_orientation.jl`) to the
+pretwitch stage means concretely: its full ancestry, not just the single
+frame where `target_name` itself first appears.
+"""
+function pretwitch_lineage_track(target_name::AbstractString, grouped::AbstractDict{String})
+    track = Tuple{Int,Point3f}[]
+    for k in 1:length(target_name)
+        prefix = target_name[1:k]
+        haskey(grouped, prefix) && append!(track, grouped[prefix])
+    end
+    sort!(track, by=first)
+    return first.(track), last.(track)
+end
+
+"""
+    pretwitch_founder_group(name::AbstractString)
+
+Classify a pretwitch cell/lineage `name` by which of the four founder cells
+(ABa, ABp, EMS, P2) it descends from, returning `:ABa`, `:ABp`, `:EMS`, or
+`:P2`.
+
+Unlike the AB lineage (which keeps growing an "AB" + a/p/l/r/d/v prefix
+indefinitely, e.g. `ABplaaappa` -- see [`get_full_lineage_df`](@ref)), the
+other two four-cell-stage founders are *renamed* at each division rather than
+suffixed: EMS -> MS + E, and P2 -> C + P3 -> D + P4 -> Z2 + Z3. So membership
+is determined by a fixed table of lineage-name prefixes rather than a single
+common root string. Verified to classify all 1332 distinct cell names in
+`final_20251205_pre-twitch_coords.csv` with no unknowns.
+"""
+function pretwitch_founder_group(name::AbstractString)
+    startswith(name, "ABa") && return :ABa
+    startswith(name, "ABp") && return :ABp
+    (name == "EMS" || startswith(name, "E") || startswith(name, "MS")) && return :EMS
+    (name == "P2" || startswith(name, "P3") || startswith(name, "P4") ||
+     startswith(name, "Z2") || startswith(name, "Z3") ||
+     startswith(name, "C") || startswith(name, "D")) && return :P2
+    error("pretwitch_founder_group: unrecognized cell name $(repr(name))")
+end
+
+"""
+    PRETWITCH_FOUNDER_COLORS
+
+Default display color for each of the four founder-cell lineage groups (see
+[`pretwitch_founder_group`](@ref)), chosen to be visually distinct from the
+red/blue/green used elsewhere for the AP/DV/LR axes themselves.
+"""
+const PRETWITCH_FOUNDER_COLORS = Dict(
+    :ABa => :orange,
+    :ABp => :purple,
+    :EMS => :cyan,
+    :P2 => :magenta,
+)
+
+"""
+    PretwitchReferenceAxes
+
+Orthonormal (`ap`, `dv`, `lr`) unit vectors and the four-cell-stage `origin`
+(centroid of ABa/ABp/P2/EMS) that anchor the pretwitch orientation scheme.
+`ap` points anterior -> posterior, `dv` points ventral -> dorsal (after
+orthogonalizing against `ap`), and `lr` completes a right-handed frame via
+`cross(ap, dv)` -- its correspondence to anatomical left/right is NOT
+resolved by this calibration alone.
+"""
+struct PretwitchReferenceAxes
+    origin::Point3f
+    ap::Vec3f
+    dv::Vec3f
+    lr::Vec3f
+end
+
+"""
+    _pretwitch_axes_from_four_points(ABa, ABp, P2, EMS)
+
+Shared orthonormal-basis construction used by both the four-cell-stage
+calibration ([`pretwitch_reference_axes`](@ref), Approach 1) and the
+per-frame lineage-midpoint scheme ([`pretwitch_axes_from_group_midpoints`](@ref),
+Approach 2): `ap` points anterior (ABa) -> posterior (P2), `dv` points ventral
+(EMS) -> dorsal (ABp) after orthogonalizing against `ap`, and `lr` completes a
+right-handed frame via `cross(ap, dv)`.
+"""
+function _pretwitch_axes_from_four_points(ABa, ABp, P2, EMS)
+    origin = Point3f((ABa .+ ABp .+ P2 .+ EMS) ./ 4)
+
+    ap = normalize(P2 - ABa)
+    dv_raw = ABp - EMS
+    dv = normalize(dv_raw - dot(dv_raw, ap) * ap)
+    lr = normalize(cross(ap, dv))
+
+    return PretwitchReferenceAxes(origin, ap, dv, lr)
+end
+
+function pretwitch_reference_axes(pretwitch_df; time::Int=0)
+    cells = pretwitch_four_cell_points(pretwitch_df; time)
+    return _pretwitch_axes_from_four_points(cells.ABa, cells.ABp, cells.P2, cells.EMS)
+end
+
+"""
+    pretwitch_axes_from_group_midpoints(group_mid)
+
+Approach 2 (see pretwitch_orientation.txt item 2): instead of interpolating a
+fixed-AP-axis compass angle (Approach 1), derive the AP/DV/LR axes fresh at
+*every* frame from the current centroid ("midpoint") of each founder's
+descendants (see [`pretwitch_founder_group`](@ref)). `group_mid` maps
+`:ABa`/`:ABp`/`:EMS`/`:P2` to that group's current-frame centroid `Point3f`
+(the same centroids already used for the star markers in the movie).
+
+Unlike Approach 1, the AP axis here is NOT fixed -- it tracks however the
+ABa/P2 descendant midpoints actually move, so this scheme captures any
+translation/curvature of the true anterior-posterior axis that the fixed-AP
+compass interpolation cannot.
+"""
+function pretwitch_axes_from_group_midpoints(group_mid::AbstractDict{Symbol})
+    return _pretwitch_axes_from_four_points(
+        group_mid[:ABa], group_mid[:ABp], group_mid[:P2], group_mid[:EMS])
+end
+
+"""
+    PretwitchAxesAtTime
+
+`ap`/`dv`/`lr` unit vectors for a single pretwitch timepoint, with `dv`/`lr`
+rotated about the fixed `reference.ap` axis by the interpolated WormGuides
+compass angle for that timepoint (see [`wormguides_compass_angle`](@ref)).
+"""
+struct PretwitchAxesAtTime
+    time::Int
+    ap::Vec3f
+    dv::Vec3f
+    lr::Vec3f
+    compass_angle_rad::Float64
+end
+
+"""
+    pretwitch_axes_at_time(reference::PretwitchReferenceAxes, time)
+
+Rotate `reference`'s DV/LR basis about the fixed AP axis by the WormGuides
+compass angle interpolated for `time`. At `time` equal to the reference's own
+four-cell-stage timepoint (compass angle 90 degrees), this reproduces
+`reference.dv`/`reference.lr` exactly by construction.
+"""
+function pretwitch_axes_at_time(reference::PretwitchReferenceAxes, time::Int)
+    frame = pretwitch_time_to_wormguides_frame(time)
+    θ = wormguides_compass_angle(frame)
+    # vector(θ) = cos(θ) * lr + sin(θ) * dv, so θ=90deg reproduces `dv` and
+    # calibrates the compass against the directly observed four-cell axes.
+    dv = cos(θ) * reference.lr + sin(θ) * reference.dv
+    lr = normalize(cross(reference.ap, dv))
+    return PretwitchAxesAtTime(time, reference.ap, dv, lr, θ)
+end

--- a/src/demo_averaging/pretwitch_straighten.jl
+++ b/src/demo_averaging/pretwitch_straighten.jl
@@ -147,6 +147,18 @@ pairs, independent of terminal status).
 frame (no curve can be fit) -- true for frames 0-169 (~47% of the pretwitch
 window), where ZERO pairs have differentiated into a real seam cell yet.
 
+`right_vector_spline` is a natural spline (same `afTime` knots as
+`central_spline`, `nothing` under the same condition) through each terminal
+pair's own `(right - left)/2` vector -- i.e. evaluating it at a parameter `x`
+gives a vector whose norm is the local left-right half-distance (a radius)
+and whose direction is the local right-ward direction, exactly analogous to
+`build_celegans_model`'s posttwitch `right_vector_afTime`. Meant for building
+circular cross-sections around the central spline (radius + orientation in
+one fit, reusing the same linearity-of-spline-fitting property `build_model.jl`
+relies on: fitting the difference directly is identical to fitting left/right
+separately and subtracting, since natural cubic interpolation at fixed knot
+parameters is a linear map).
+
 `is_ap_monotonic` is a diagnostic ONLY: whether this frame's nominal knot
 order also happens to be spatially monotonic along the fixed AP reference
 axis. It does not affect the fit. `false` means the seam-cell ancestors
@@ -160,6 +172,7 @@ struct PretwitchCentralSplineFrame
     knot_positions::Vector{Point3f}
     afTime::Vector{Float64}
     central_spline::Union{Nothing,BSplineKit.SplineWrapper}
+    right_vector_spline::Union{Nothing,BSplineKit.SplineWrapper}
     pair_confidence::Vector{PairConfidence}
     is_ap_monotonic::Union{Missing,Bool}
 end
@@ -214,14 +227,18 @@ function central_spline_frame(tracks::Vector{PretwitchPairTrack}, i::Int, lr_w::
         afTime = Float64[0; cumsum(deltaLengths)]
         afTime ./= afTime[end]
         central_spline = _fit_central_spline(afTime, knot_positions)
+
+        right_vectors = [Vec3f((tracks[k].right[i] .- tracks[k].left[i]) ./ 2) for k in terminal_stations]
+        right_vector_spline = _fit_central_spline(afTime, right_vectors)
     else
         is_ap_monotonic = missing
         afTime = Float64[]
         central_spline = nothing
+        right_vector_spline = nothing
     end
 
     confidences = [pair_confidence(tracks[k], i, lr_w, max_abs_weight) for k in 1:n]
-    return PretwitchCentralSplineFrame(i - 1, terminal_stations, knot_positions, afTime, central_spline, confidences, is_ap_monotonic)
+    return PretwitchCentralSplineFrame(i - 1, terminal_stations, knot_positions, afTime, central_spline, right_vector_spline, confidences, is_ap_monotonic)
 end
 
 """

--- a/src/demo_averaging/pretwitch_straighten.jl
+++ b/src/demo_averaging/pretwitch_straighten.jl
@@ -1,0 +1,258 @@
+# Pretwitch central-spline construction (see pretwitch_orientation.txt and
+# this session's design discussion for the full rationale).
+#
+# Mirrors src/build_model.jl's posttwitch central spline (fit through the
+# midpoints of 10 left/right seam-cell pairs), but pretwitch data has no
+# seam cells yet -- only their embryonic-lineage ancestors. Ancestor
+# positions are reconstructed via pretwitch_lineage_track (splicing together
+# the ancestor chain, as seam_cell_to_lineage_map.jl's
+# get_full_lineage_seam_cell_points already does for a single seam cell).
+#
+# The spline is built ONLY from TERMINAL seam cells -- pairs whose ancestor
+# tracking has reached the exact final named seam-cell identity (both L and
+# R), not merely some shorter, still-dividing ancestor prefix. Connecting
+# undifferentiated shared ancestors (e.g. H0 and H1 both still being nothing
+# more than "whatever ABa/ABp average to" before either has committed to
+# becoming a seam cell) doesn't represent real seam-cell geometry -- it's a
+# stand-in for cells that don't exist as such yet. Once restricted to
+# terminal cells, no two stations can ever coincide (each is a real, distinct
+# differentiated cell), so no merge/dedup step is needed at all.
+#
+# The practical cost: terminal seam cells don't exist until quite late.
+# Confirmed empirically: ZERO of the 10 pairs are terminal for frames 0-169
+# (the first 47% of the pretwitch window); the count then climbs
+# non-monotonically and only reaches its max (9 of 10 -- V5's pair never
+# reaches its exact terminal name within this dataset, stopping one division
+# short) from frame ~204 onward. So for roughly the first half of the movie
+# there may be too few terminal knots (or none) to fit any spline at all --
+# `PretwitchCentralSplineFrame.central_spline` is `nothing` in that case.
+
+"""
+    PretwitchPairTrack
+
+Full per-frame (0:360) reconstruction for one canonical AP-order left/right
+seam-cell pair (e.g. "H0"). `left_name`/`right_name` are the currently
+active spliced ancestor name backing `left[t+1]`/`right[t+1]` (see
+[`pretwitch_lineage_track`](@ref)); `left_name[i] == right_name[i]` means
+this pair has not yet diverged into two distinct cells at that frame.
+`target_left`/`target_right` are the exact final seam-cell lineage names
+(from `seam_cell_to_lineage_map`) that `left_name[i]`/`right_name[i]` must
+equal for this pair to count as TERMINAL (a real, fully differentiated seam
+cell) at frame `i`.
+"""
+struct PretwitchPairTrack
+    name::String
+    left_name::Vector{String}
+    right_name::Vector{String}
+    left::Vector{Point3f}
+    right::Vector{Point3f}
+    target_left::String
+    target_right::String
+end
+
+"""
+    is_terminal(track::PretwitchPairTrack, i::Int)
+
+Whether pair `track` is a real, fully differentiated (not merely a shared,
+still-dividing ancestor) seam cell at frame index `i` -- i.e. both
+`left_name[i]` and `right_name[i]` have reached their exact final lineage
+name.
+"""
+is_terminal(track::PretwitchPairTrack, i::Int) =
+    track.left_name[i] == track.target_left && track.right_name[i] == track.target_right
+
+"""
+    pretwitch_pair_tracks(pretwitch_df=get_pretwitch_df())
+
+Build a [`PretwitchPairTrack`](@ref) for each of the 10 canonical L/R
+seam-cell pairs (`left_seam_cells`/`right_seam_cells`, anterior->posterior
+order), reconstructing each side's full ancestor-spliced position track via
+[`pretwitch_lineage_track`](@ref).
+"""
+function pretwitch_pair_tracks(pretwitch_df=get_pretwitch_df())
+    grouped = pretwitch_cells_by_name(pretwitch_df)
+    map(zip(left_seam_cells, right_seam_cells)) do (l, r)
+        target_left, target_right = seam_cell_to_lineage_map[l], seam_cell_to_lineage_map[r]
+        lt, lp, ln = pretwitch_lineage_track(target_left, grouped)
+        rt, rp, rn = pretwitch_lineage_track(target_right, grouped)
+        @assert lt == rt "pretwitch_pair_tracks: L/R frame coverage mismatch for pair $l/$r"
+        PretwitchPairTrack(replace(l, 'L' => ""), ln, rn, lp, rp, target_left, target_right)
+    end
+end
+
+"""
+    PairConfidence
+
+Diagnostic-only confidence that a pair's midpoint approximates a true
+bilateral average, for one pair at one frame. When `diverged` (left/right
+resolve to different named cells), the midpoint is a real L/R average and is
+always trusted (`score=1`). When not yet diverged, the midpoint is really
+just that one shared, not-yet-split cell's own position -- `score` then
+comes from how strongly the regression (`pretwitch_axis_regression_weights.csv`,
+see scripts/regress_pretwitch_axis_weights.jl) found that specific cell's
+position to correlate with the true LR axis: a cell already sitting well off
+the midline (large `|lr_weight|`) is scored as less trustworthy as a midline
+stand-in, even though structurally it looks "undiverged."
+"""
+struct PairConfidence
+    diverged::Bool
+    lr_weight_left::Float64
+    lr_weight_right::Float64
+    score::Float64
+end
+
+"""
+    load_lr_weights(csv_path=<repo root>/pretwitch_axis_regression_weights.csv)
+
+Load the `name => lr_weight` column of the regression CSV. Returns an empty
+`Dict` (all names default to weight 0, i.e. `score=1`, fully trusted) if the
+CSV doesn't exist -- it's gitignored/regenerated, not committed, so this
+degrades gracefully on a fresh checkout instead of erroring.
+"""
+function load_lr_weights(csv_path=joinpath(@__DIR__, "..", "..", "pretwitch_axis_regression_weights.csv"))
+    lr_w = Dict{String,Float64}()
+    isfile(csv_path) || return lr_w
+    open(csv_path) do io
+        readline(io)  # header
+        for line in eachline(io)
+            parts = split(line, ',')
+            lr_w[parts[1]] = parse(Float64, parts[4])
+        end
+    end
+    return lr_w
+end
+
+function pair_confidence(track::PretwitchPairTrack, i::Int, lr_w::AbstractDict{String,Float64}, max_abs_weight::Float64)
+    ln, rn = track.left_name[i], track.right_name[i]
+    diverged = ln != rn
+    wl, wr = get(lr_w, ln, 0.0), get(lr_w, rn, 0.0)
+    score = diverged ? 1.0 : clamp(1.0 - abs(wl) / max_abs_weight, 0.0, 1.0)
+    return PairConfidence(diverged, wl, wr, score)
+end
+
+"""
+    PretwitchCentralSplineFrame
+
+One pretwitch timepoint's central-spline state: the fitted natural spline
+(parameterized by normalized arc length, `afTime ∈ [0,1]`, exactly as
+`build_celegans_model`'s posttwitch `center_spline`) through whichever
+stations are currently TERMINAL (see [`is_terminal`](@ref)), in fixed
+NOMINAL fate order (H0,H1,H2,V1..V6,T -- never re-sorted by current spatial
+position, so a knot's anatomical identity is consistent across every frame),
+`terminal_stations` (1-based nominal indices of the knots actually used), and
+per-pair diagnostic [`PairConfidence`](@ref) (still reported for all 10
+pairs, independent of terminal status).
+
+`central_spline` is `nothing` when fewer than 2 stations are terminal this
+frame (no curve can be fit) -- true for frames 0-169 (~47% of the pretwitch
+window), where ZERO pairs have differentiated into a real seam cell yet.
+
+`is_ap_monotonic` is a diagnostic ONLY: whether this frame's nominal knot
+order also happens to be spatially monotonic along the fixed AP reference
+axis. It does not affect the fit. `false` means the seam-cell ancestors
+haven't yet spatially sorted into their final AP body order at this
+frame -- expected during gastrulation-stage rearrangement, not an error.
+`missing` when fewer than 2 knots (monotonicity is undefined/vacuous).
+"""
+struct PretwitchCentralSplineFrame
+    time::Int
+    terminal_stations::Vector{Int}
+    knot_positions::Vector{Point3f}
+    afTime::Vector{Float64}
+    central_spline::Union{Nothing,BSplineKit.SplineWrapper}
+    pair_confidence::Vector{PairConfidence}
+    is_ap_monotonic::Union{Missing,Bool}
+end
+
+"""
+    _fit_central_spline(afTime, knot_positions)
+
+Fit a natural spline through `knot_positions`, exactly as
+[`ParametricSplines.interpolate_natural_cubic_spline`](@ref) does for the
+posttwitch model (which always has exactly 10 knots) -- EXCEPT that a
+terminal-only pretwitch frame can have as few as 2 knots, and `BSplineKit`'s
+natural cubic (`BSplineOrder(4)`) interpolation is only evaluable with >=4
+points (verified directly: it *constructs* with 3 but throws `ArgumentError:
+wrong number of coefficients` when called). `Natural` boundary conditions are
+also only supported for even spline orders. So: use cubic (order 4) when
+there are enough knots, otherwise fall back to a natural linear spline
+(order 2, i.e. a polyline/straight segment) -- a reasonable representation
+for 2-3 widely-spaced knots anyway. Caller must ensure `length(knot_positions) >= 2`.
+"""
+function _fit_central_spline(afTime, knot_positions)
+    order = length(knot_positions) >= 4 ? 4 : 2
+    return BSplineKit.interpolate(afTime, knot_positions, BSplineKit.BSplineOrder(order), BSplineKit.Natural())
+end
+
+"""
+    central_spline_frame(tracks, i, lr_w, max_abs_weight, ap_ref)
+
+Build one [`PretwitchCentralSplineFrame`](@ref) at pair-track index `i`
+(frame time `i-1`): select only currently-TERMINAL pairs (real, fully
+differentiated seam cells -- see [`is_terminal`](@ref)), fit a natural spline
+through their midpoints (see [`_fit_central_spline`](@ref)) when there are
+enough of them, and compute per-pair diagnostic confidence for all 10 pairs
+regardless of terminal status.
+"""
+function central_spline_frame(tracks::Vector{PretwitchPairTrack}, i::Int, lr_w::AbstractDict{String,Float64}, max_abs_weight::Float64, ap_ref::PretwitchReferenceAxes)
+    n = length(tracks)
+    terminal_stations = [k for k in 1:n if is_terminal(tracks[k], i)]
+    knot_positions = [Point3f((tracks[k].left[i] .+ tracks[k].right[i]) ./ 2) for k in terminal_stations]
+
+    if length(knot_positions) >= 2
+        # Diagnostic only (does NOT affect the fit): does this frame's
+        # nominal order also happen to be spatially monotonic along the
+        # fixed AP reference axis? Early-to-mid development frequently
+        # answers "no" -- the seam-cell ancestors are still undergoing
+        # gastrulation-like rearrangement and are not yet sorted into their
+        # final AP body order. That's a real developmental signal, not a bug
+        # to fix by reordering.
+        ap_projections = [dot(p - ap_ref.origin, ap_ref.ap) for p in knot_positions]
+        is_ap_monotonic = issorted(ap_projections)
+
+        deltaLengths = norm.(diff(knot_positions))
+        afTime = Float64[0; cumsum(deltaLengths)]
+        afTime ./= afTime[end]
+        central_spline = _fit_central_spline(afTime, knot_positions)
+    else
+        is_ap_monotonic = missing
+        afTime = Float64[]
+        central_spline = nothing
+    end
+
+    confidences = [pair_confidence(tracks[k], i, lr_w, max_abs_weight) for k in 1:n]
+    return PretwitchCentralSplineFrame(i - 1, terminal_stations, knot_positions, afTime, central_spline, confidences, is_ap_monotonic)
+end
+
+"""
+    PretwitchCentralSplineSeries
+
+`frames[i].time == i-1` for `i in 1:361`; `station_names` gives the 10
+canonical AP-order pair names (`"H0"`, ..., `"T"`) that `pair_confidence`
+(and `terminal_stations`, by 1-based index) refer to.
+"""
+struct PretwitchCentralSplineSeries
+    frames::Vector{PretwitchCentralSplineFrame}
+    station_names::Vector{String}
+end
+
+"""
+    build_pretwitch_central_spline_series(pretwitch_df=get_pretwitch_df())
+
+Build the full 361-frame [`PretwitchCentralSplineSeries`](@ref): per frame,
+fit a central spline through whichever seam-cell pairs are currently
+TERMINAL (real, fully differentiated cells -- see [`is_terminal`](@ref)).
+No pair is terminal before frame 170; the count then climbs
+non-monotonically, reaching 9 of 10 (V5 never reaches its exact terminal
+name in this dataset) from around frame 204 onward. `central_spline` is
+`nothing` for frames with fewer than 2 terminal pairs.
+"""
+function build_pretwitch_central_spline_series(pretwitch_df=get_pretwitch_df())
+    tracks = pretwitch_pair_tracks(pretwitch_df)
+    lr_w = load_lr_weights()
+    max_abs_weight = isempty(lr_w) ? 1.0 : maximum(abs, values(lr_w))
+    ap_ref = pretwitch_reference_axes(pretwitch_df)
+    n_times = length(tracks[1].left)
+    frames = [central_spline_frame(tracks, i, lr_w, max_abs_weight, ap_ref) for i in 1:n_times]
+    return PretwitchCentralSplineSeries(frames, [tr.name for tr in tracks])
+end


### PR DESCRIPTION
## Summary
- Establishes AP/DV/LR orientation axes for the pretwitch embryo via three approaches: WormGuides compass interpolation (Approach 1), per-frame lineage-midpoint recomputation (Approach 2), and a ridge regression fitting ~1300 individual cell trajectories against Approach 1's axes with a train/test validation split (Approach 3), plus ancestor-lineage reconstruction to cross-check known posttwitch DV/LR marker cells (Cpaaaa, Caaaaa, ABplaappap, ABarpaappp) back through the pretwitch window.
- Builds a pretwitch central spline analogous to `build_celegans_model`'s posttwitch central spline, but fit only through **terminal** seam-cell pairs (real, fully differentiated cells — no pair is terminal before t=170, ~47% into the window) rather than still-dividing shared ancestors.
- Adds a body-surface tube around a curve that linearly interpolates between a medial axis (spanning the full point cloud's AP extent) and the terminal-cell spline, with a cross-sectional radius that tapers along AP (adaptive, density-scaled slice widths + explicit smoothing), reusing the existing `get_circle_points`/`get_model_contour_mesh` posttwitch mesh utilities.
- Verification movies for each stage (`scripts/movie_pretwitch_*.jl`, `scripts/regress_pretwitch_axis_weights.jl`, `scripts/scan_pretwitch_axis_candidates.jl`).

## Test plan
- [ ] `julia --project=web -e 'using ShroffCelegansModels'` loads cleanly
- [ ] `julia --project=web scripts/movie_pretwitch_central_spline.jl` renders both `pretwitch_central_spline.mp4` and `pretwitch_central_spline_with_surface.mp4` without error
- [ ] Visual spot-check of the rendered movies: axes look anatomically reasonable, central spline/body surface taper smoothly and match seam-cell positions once terminal